### PR TITLE
Update build.ts

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -133,12 +133,12 @@ export async function build(
 
 	const buildId = await getBuildId();
 
-	const clientConfig = await makeViteConfig(config, deploymentTarget, buildId, {
+	const getClientConfig = async () => await makeViteConfig(config, deploymentTarget, buildId, {
 		ssr: false,
 	});
 
 	await viteBuild({
-		...clientConfig,
+		...await getClientConfig(),
 
 		build: {
 			outDir: clientOutDir,


### PR DESCRIPTION
Here is a beginning solution to address an issue with build.

When working with plugins, the configuration is shared for both front and back, and only created once.
I tried with this one for example : https://www.npmjs.com/package/rollup-plugin-visualizer

The issue with the previous plugin, is that the output file `stats.html` is created once for client, then erased when the server build.

There is actually no way to make a difference between the two builds : 
![image](https://user-images.githubusercontent.com/5599375/147517188-c8a41d6d-e735-425e-8e40-b8f3b1032f5d.png)
Returns : 
![image](https://user-images.githubusercontent.com/5599375/147517235-bed4032c-a7b0-428c-954a-3b26821f90b5.png)

Maybe adding an option to differentiate builds could help to load different plugins for client and server and also help with this kind of plugins.