### PR TITLE
fix: build error on Windows related to dynamic import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"version": "0.5.0",
 	"description": "Rakkas.js workspace root",
 	"scripts": {
-		"check": "pnpm run -r check '--filter=!rakkas-styled-components-testbed'",
-		"dev": "pnpm run -r --filter=./packages '--filter=!create-rakkas-app' --parallel dev",
+		"check": "pnpm run -r --filter=./packages --filter='!rakkas-styled-components-testbed' check",
+		"dev": "pnpm run -r --filter=./packages --filter='!create-rakkas-app' --parallel dev",
 		"build": "pnpm run -r build",
 		"precommit": "lint-staged",
 		"prepare": "husky install",

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,7 +1,7 @@
+import chalk from "chalk";
+import { build } from "esbuild";
 import fs from "fs";
 import path from "path";
-import { build } from "esbuild";
-import chalk from "chalk";
 import type {
 	Config,
 	ConfigFactoryInfo,
@@ -9,6 +9,7 @@ import type {
 	RakkasCommand,
 	RakkasDeploymentTarget,
 } from "../..";
+import { importJs } from "./importJs";
 
 export interface ConfigConfig {
 	command: RakkasCommand;
@@ -39,9 +40,7 @@ export async function loadConfig(configConfig: ConfigConfig): Promise<{
 		configConfig.collectDeps,
 	);
 
-	let loaded = await (0, eval)(
-		`import(${JSON.stringify(outfile + "?" + Math.random())})`,
-	);
+	let loaded = await importJs(outfile + "?" + Math.random());
 
 	while (loaded.default) loaded = loaded.default;
 

--- a/packages/cli/src/lib/importJs.ts
+++ b/packages/cli/src/lib/importJs.ts
@@ -1,0 +1,13 @@
+import { normalizePath } from "vite";
+
+/**
+ * Wrapper function of dynamic import to ensure normalizing the path
+ */
+export async function importJs(path: string): Promise<any> {
+	const normalizedPath = normalizePath(path);
+	return await (0, eval)(
+		`import(${JSON.stringify(
+			normalizedPath.startsWith("/") ? normalizedPath : "/" + normalizedPath,
+		)})`,
+	);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,8 @@ importers:
 
   website:
     specifiers:
+      '@docsearch/css': ^3.0.0-alpha.50
+      '@docsearch/react': ^3.0.0-alpha.50
       '@mapbox/rehype-prism': ^0.8.0
       '@mdx-js/mdx': ^1.6.22
       '@mdx-js/react': ^1.6.22
@@ -731,6 +733,8 @@ importers:
       react-helmet-async: 1.2.2_react-dom@17.0.2+react@17.0.2
       sanitize.css: 13.0.0
     devDependencies:
+      '@docsearch/css': 3.0.0
+      '@docsearch/react': 3.0.0_5539cae010396b202b015f3568914e95
       '@mapbox/rehype-prism': 0.8.0
       '@mdx-js/mdx': 1.6.22
       '@rakkasjs/cli': link:../packages/cli
@@ -754,6 +758,116 @@ importers:
       vite-plugin-mdx: 3.5.10_@mdx-js+mdx@1.6.22
 
 packages:
+
+  /@algolia/autocomplete-core/1.5.2:
+    resolution: {integrity: sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==}
+    dependencies:
+      '@algolia/autocomplete-shared': 1.5.2
+    dev: true
+
+  /@algolia/autocomplete-preset-algolia/1.5.2_algoliasearch@4.12.1:
+    resolution: {integrity: sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==}
+    peerDependencies:
+      '@algolia/client-search': ^4.9.1
+      algoliasearch: ^4.9.1
+    dependencies:
+      '@algolia/autocomplete-shared': 1.5.2
+      algoliasearch: 4.12.1
+    dev: true
+
+  /@algolia/autocomplete-shared/1.5.2:
+    resolution: {integrity: sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug==}
+    dev: true
+
+  /@algolia/cache-browser-local-storage/4.12.1:
+    resolution: {integrity: sha512-ERFFOnC9740xAkuO0iZTQqm2AzU7Dpz/s+g7o48GlZgx5p9GgNcsuK5eS0GoW/tAK+fnKlizCtlFHNuIWuvfsg==}
+    dependencies:
+      '@algolia/cache-common': 4.12.1
+    dev: true
+
+  /@algolia/cache-common/4.12.1:
+    resolution: {integrity: sha512-UugTER3V40jT+e19Dmph5PKMeliYKxycNPwrPNADin0RcWNfT2QksK9Ff2N2W7UKraqMOzoeDb4LAJtxcK1a8Q==}
+    dev: true
+
+  /@algolia/cache-in-memory/4.12.1:
+    resolution: {integrity: sha512-U6iaunaxK1lHsAf02UWF58foKFEcrVLsHwN56UkCtwn32nlP9rz52WOcHsgk6TJrL8NDcO5swMjtOQ5XHESFLw==}
+    dependencies:
+      '@algolia/cache-common': 4.12.1
+    dev: true
+
+  /@algolia/client-account/4.12.1:
+    resolution: {integrity: sha512-jGo4ConJNoMdTCR2zouO0jO/JcJmzOK6crFxMMLvdnB1JhmMbuIKluOTJVlBWeivnmcsqb7r0v7qTCPW5PAyxQ==}
+    dependencies:
+      '@algolia/client-common': 4.12.1
+      '@algolia/client-search': 4.12.1
+      '@algolia/transporter': 4.12.1
+    dev: true
+
+  /@algolia/client-analytics/4.12.1:
+    resolution: {integrity: sha512-h1It7KXzIthlhuhfBk7LteYq72tym9maQDUsyRW0Gft8b6ZQahnRak9gcCvKwhcJ1vJoP7T7JrNYGiYSicTD9g==}
+    dependencies:
+      '@algolia/client-common': 4.12.1
+      '@algolia/client-search': 4.12.1
+      '@algolia/requester-common': 4.12.1
+      '@algolia/transporter': 4.12.1
+    dev: true
+
+  /@algolia/client-common/4.12.1:
+    resolution: {integrity: sha512-obnJ8eSbv+h94Grk83DTGQ3bqhViSWureV6oK1s21/KMGWbb3DkduHm+lcwFrMFkjSUSzosLBHV9EQUIBvueTw==}
+    dependencies:
+      '@algolia/requester-common': 4.12.1
+      '@algolia/transporter': 4.12.1
+    dev: true
+
+  /@algolia/client-personalization/4.12.1:
+    resolution: {integrity: sha512-sMSnjjPjRgByGHYygV+5L/E8a6RgU7l2GbpJukSzJ9GRY37tHmBHuvahv8JjdCGJ2p7QDYLnQy5bN5Z02qjc7Q==}
+    dependencies:
+      '@algolia/client-common': 4.12.1
+      '@algolia/requester-common': 4.12.1
+      '@algolia/transporter': 4.12.1
+    dev: true
+
+  /@algolia/client-search/4.12.1:
+    resolution: {integrity: sha512-MwwKKprfY6X2nJ5Ki/ccXM2GDEePvVjZnnoOB2io3dLKW4fTqeSRlC5DRXeFD7UM0vOPPHr4ItV2aj19APKNVQ==}
+    dependencies:
+      '@algolia/client-common': 4.12.1
+      '@algolia/requester-common': 4.12.1
+      '@algolia/transporter': 4.12.1
+    dev: true
+
+  /@algolia/logger-common/4.12.1:
+    resolution: {integrity: sha512-fCgrzlXGATNqdFTxwx0GsyPXK+Uqrx1SZ3iuY2VGPPqdt1a20clAG2n2OcLHJpvaa6vMFPlJyWvbqAgzxdxBlQ==}
+    dev: true
+
+  /@algolia/logger-console/4.12.1:
+    resolution: {integrity: sha512-0owaEnq/davngQMYqxLA4KrhWHiXujQ1CU3FFnyUcMyBR7rGHI48zSOUpqnsAXrMBdSH6rH5BDkSUUFwsh8RkQ==}
+    dependencies:
+      '@algolia/logger-common': 4.12.1
+    dev: true
+
+  /@algolia/requester-browser-xhr/4.12.1:
+    resolution: {integrity: sha512-OaMxDyG0TZG0oqz1lQh9e3woantAG1bLnuwq3fmypsrQxra4IQZiyn1x+kEb69D2TcXApI5gOgrD4oWhtEVMtw==}
+    dependencies:
+      '@algolia/requester-common': 4.12.1
+    dev: true
+
+  /@algolia/requester-common/4.12.1:
+    resolution: {integrity: sha512-XWIrWQNJ1vIrSuL/bUk3ZwNMNxl+aWz6dNboRW6+lGTcMIwc3NBFE90ogbZKhNrFRff8zI4qCF15tjW+Fyhpow==}
+    dev: true
+
+  /@algolia/requester-node-http/4.12.1:
+    resolution: {integrity: sha512-awBtwaD+s0hxkA1aehYn8F0t9wqGoBVWgY4JPHBmp1ChO3pK7RKnnvnv7QQa9vTlllX29oPt/BBVgMo1Z3n1Qg==}
+    dependencies:
+      '@algolia/requester-common': 4.12.1
+    dev: true
+
+  /@algolia/transporter/4.12.1:
+    resolution: {integrity: sha512-BGeNgdEHc6dXIk2g8kdlOoQ6fQ6OIaKQcplEj7HPoi+XZUeAvRi3Pff3QWd7YmybWkjzd9AnTzieTASDWhL+sQ==}
+    dependencies:
+      '@algolia/cache-common': 4.12.1
+      '@algolia/logger-common': 4.12.1
+      '@algolia/requester-common': 4.12.1
+    dev: true
 
   /@alloc/quick-lru/5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1332,6 +1446,28 @@ packages:
     dependencies:
       debug: 3.2.7
       lodash.once: 4.1.1
+    dev: true
+
+  /@docsearch/css/3.0.0:
+    resolution: {integrity: sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA==}
+    dev: true
+
+  /@docsearch/react/3.0.0_5539cae010396b202b015f3568914e95:
+    resolution: {integrity: sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==}
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 18.0.0'
+      react: '>= 16.8.0 < 18.0.0'
+      react-dom: '>= 16.8.0 < 18.0.0'
+    dependencies:
+      '@algolia/autocomplete-core': 1.5.2
+      '@algolia/autocomplete-preset-algolia': 1.5.2_algoliasearch@4.12.1
+      '@docsearch/css': 3.0.0
+      '@types/react': 17.0.37
+      algoliasearch: 4.12.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    transitivePeerDependencies:
+      - '@algolia/client-search'
     dev: true
 
   /@emotion/is-prop-valid/0.8.8:
@@ -2475,6 +2611,25 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+    dev: true
+
+  /algoliasearch/4.12.1:
+    resolution: {integrity: sha512-c0dM1g3zZBJrkzE5GA/Nu1y3fFxx3LCzxKzcmp2dgGS8P4CjszB/l3lsSh2MSrrK1Hn/KV4BlbBMXtYgG1Bfrw==}
+    dependencies:
+      '@algolia/cache-browser-local-storage': 4.12.1
+      '@algolia/cache-common': 4.12.1
+      '@algolia/cache-in-memory': 4.12.1
+      '@algolia/client-account': 4.12.1
+      '@algolia/client-analytics': 4.12.1
+      '@algolia/client-common': 4.12.1
+      '@algolia/client-personalization': 4.12.1
+      '@algolia/client-search': 4.12.1
+      '@algolia/logger-common': 4.12.1
+      '@algolia/logger-console': 4.12.1
+      '@algolia/requester-browser-xhr': 4.12.1
+      '@algolia/requester-common': 4.12.1
+      '@algolia/requester-node-http': 4.12.1
+      '@algolia/transporter': 4.12.1
     dev: true
 
   /ansi-align/2.0.0:
@@ -8309,6 +8464,7 @@ packages:
 
   /node-addon-api/3.2.1:
     resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -8342,6 +8498,7 @@ packages:
   /node-gyp-build/4.3.0:
     resolution: {integrity: sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
This PR fixes a build error on Windows.

Running `rakkas build` on Windows throws error like this:

```
node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

`path.resolve` on Windows returns an  absolute path that starts with drive letters like `C:` , and `import` does not accept a path with drive letters. That's why building on Windows throws the error.

In this case, appending `/` to the head of the path (like `/C:/foo/bar`) solves the problem. `vite` also uses dynamic import, but avoiding the problem to normalize a path before importing.

Similar case: https://github.com/vitejs/vite/issues/1487

