### PR TITLE
Fix: wrong manifest generation on Windows for static build

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -188,7 +188,7 @@ export async function build(
 
 	const manifest = Object.fromEntries(
 		Object.entries(rawManifest)
-			.map(([name, value]) => {
+			.map(([name, value]): [string, string[]] | undefined => {
 				const relative = path.relative(pagesDir, path.resolve("src", name));
 				if (
 					relative &&
@@ -205,10 +205,13 @@ export async function build(
 						assets.forEach((x) => assetSet.add(x));
 					}
 
-					return [path.join("/", config.pagesDir, relative), [...assetSet]];
+					return [
+						path.join("/", config.pagesDir, relative).replace(/\\/g, "/"),
+						[...assetSet],
+					];
 				}
 			})
-			.filter(Boolean) as Array<[string, string[]]>,
+			.filter((x): x is [string, string[]] => !!x),
 	);
 
 	if (deploymentTarget !== "static") {

--- a/testbed/static/cypress/integration/static.spec.ts
+++ b/testbed/static/cypress/integration/static.spec.ts
@@ -4,6 +4,14 @@ describe("Static content", () => {
 		cy.contains("Rakkas static site generation demo");
 	});
 
+	it("loads a stylesheet with JavaScript disabled", () => {
+		cy.request("/")
+			.its("body")
+			.should("satisfy", (html: string) => {
+				return html.match(/href="\/assets\/page\..+\.css"/);
+			});
+	});
+
 	it("visits a profile page", () => {
 		cy.visit("/profile/3");
 		cy.contains("Lillian Taylor");

--- a/testbed/static/src/pages/page.tsx
+++ b/testbed/static/src/pages/page.tsx
@@ -1,6 +1,7 @@
-import React from "react";
 import { definePage, DefinePageTypes } from "rakkasjs";
+import React from "react";
 import { Helmet } from "react-helmet-async";
+import "./styles.css";
 
 export type IndexPageTypes = DefinePageTypes<never>;
 

--- a/testbed/static/src/pages/styles.css
+++ b/testbed/static/src/pages/styles.css
@@ -1,0 +1,3 @@
+p {
+	font-weight: bold;
+}


### PR DESCRIPTION
`rakkas build -d static` generates `index.html` without `<link rel="stylesheet" />` on Windows because of wrong manifest generation. This PR fixes the issue to normalize paths in the manifest.


On the current version(0.5.2), the manifest has Windows-styled paths because `path.join`(Line 208) returns a path including back shashes on Windows.
https://github.com/rakkasjs/rakkasjs/blob/58e3d05b3e96297d4d840cdcaf18f59a737b9c51/packages/cli/src/commands/build.ts#L189-L212

When collecting assets, `rakkas` uses manifest and Poisx-styled path names. The manifest has Windows-styled paths on Windows, so `assets` is always `undefined` . That's why `<link />` tags are missing. https://github.com/rakkasjs/rakkasjs/blob/eee16c59f579fea8e15871d92fb1b1d12fbd387b/packages/rakkasjs/src/server.tsx#L490-L503

