### PR TITLE
fix: remove `setTimeout` polyfill on Lagon entry

### DIFF
--- a/packages/rakkasjs/src/vite-plugin/adapters.ts
+++ b/packages/rakkasjs/src/vite-plugin/adapters.ts
@@ -364,8 +364,6 @@ const LAGON_ENTRY = `
 	import lagonAdapter from "@hattip/adapter-lagon";
 	import hattipHandler from "./hattip.js";
 
-	globalThis.setTimeout = (callback) => Promise.resolve().then(callback);
-
 	const originalFormData = Request.prototype.formData;
 	Request.prototype.formData = async function () {
 		if (this.headers.get("content-type")?.startsWith("multipart/form-data")) {


### PR DESCRIPTION
As of version `0.1.0` of the runtime and `0.4.5` of the CLI, Lagon now natively supports timers APIs (https://github.com/lagonapp/lagon/pull/460).

This PR removes the `setTimeout` polyfill that isn't needed anymore.