### PR TITLE
Add example of Cloudflare binding

### DIFF
--- a/website/src/routes/_site/guide/cloudflare-workers.page.mdx
+++ b/website/src/routes/_site/guide/cloudflare-workers.page.mdx
@@ -54,10 +54,13 @@ import hattipHandler from './entry-hattip';
 import { BetaDatabase } from '@miniflare/d1';
 import { createSQLiteDB } from '@miniflare/shared';
 import fs from 'fs';
+
 fs.mkdirSync('./data', { recursive: true });
+
 const dbPromise = Promise.resolve()
   .then(() => createSQLiteDB('./data/data.db'))
   .then((db) => new BetaDatabase(db));
+  
 export default createMiddleware(async (context) => {
   const db = await dbPromise;
   context.platform.env = context.platform.env ?? {};

--- a/website/src/routes/_site/guide/cloudflare-workers.page.mdx
+++ b/website/src/routes/_site/guide/cloudflare-workers.page.mdx
@@ -44,3 +44,24 @@ After building with `rakkas build`, you can publish your project with `wrangler 
 ## Cloudflare Workers-specific APIs
 
 During development, Rakkas applications always run on Node.js regardless of the `adapter` setting. As such, Cloudflare Workers-specific APIs like the KV store and durable objects are not available. You can polyfill them using, e.g., [`@miniflare/kv`](https://github.com/cloudflare/miniflare/tree/master/packages/kv) and [@miniflare/durable-objects](https://github.com/cloudflare/miniflare/tree/master/packages/durable-objects) packages in a [custom Node.js entry](node#custom-entry).
+
+For example, to simulate a D1 database with the binding `CLOUDFLARE_DB` during development:
+
+```ts
+// src/entry-node.ts
+import { createMiddleware } from 'rakkasjs/node-adapter';
+import hattipHandler from './entry-hattip';
+import { BetaDatabase } from '@miniflare/d1';
+import { createSQLiteDB } from '@miniflare/shared';
+import fs from 'fs';
+fs.mkdirSync('./data', { recursive: true });
+const dbPromise = Promise.resolve()
+  .then(() => createSQLiteDB('./data/data.db'))
+  .then((db) => new BetaDatabase(db));
+export default createMiddleware(async (context) => {
+  const db = await dbPromise;
+  context.platform.env = context.platform.env ?? {};
+  context.platform.env.CLOUDFLARE_DB = db;
+  return hattipHandler(context);
+});
+```


### PR DESCRIPTION
I had some trouble figuring out how to prepare the entry-node.ts to use Cloudflare bindings.

Using the Miniflare APIs is kind of confusing by itself, as well as how to modify the createMiddleware function to include custom logic. Even the linked https://rakkasjs.org/guide/node#custom-entry page shows some code like `app.use(createMiddleware(hattipHandler))` which only works with an Express-like framework. It took me a while to realize I could just put the custom callback inside of createMiddleware function.

I think it would be nice to include a Cloudflare-specific example that does not require Express or a similar framework here.

In case it could help, I added an example based on my own experiment project here: https://github.com/patdx/edge-cms/blob/main/src/entry-node.ts But feel free to disregard this suggestion or anything you like too. :)