### PR TITLE
copyright year modified using Date, not hard coded

### DIFF
--- a/website/src/routes/_site/layout.tsx
+++ b/website/src/routes/_site/layout.tsx
@@ -37,7 +37,7 @@ const MainLayout: Layout = ({ children }) => (
 
 		<footer className={css.footer}>
 			<p>
-				Software and documentation: Copyright 2021 Fatih Aygün. MIT License.
+				Software and documentation: Copyright {new Date().getFullYear()} Fatih Aygün. MIT License.
 			</p>
 
 			<p>

--- a/website/src/routes/_site/layout.tsx
+++ b/website/src/routes/_site/layout.tsx
@@ -37,7 +37,8 @@ const MainLayout: Layout = ({ children }) => (
 
 		<footer className={css.footer}>
 			<p>
-				Software and documentation: Copyright 2021-{new Date().getFullYear()} Fatih Aygün. MIT License.
+				Software and documentation: Copyright 2021-{new Date().getFullYear()}{" "}
+				Fatih Aygün. MIT License.
 			</p>
 
 			<p>

--- a/website/src/routes/_site/layout.tsx
+++ b/website/src/routes/_site/layout.tsx
@@ -37,7 +37,7 @@ const MainLayout: Layout = ({ children }) => (
 
 		<footer className={css.footer}>
 			<p>
-				Software and documentation: Copyright {new Date().getFullYear()} Fatih Aygün. MIT License.
+				Software and documentation: Copyright 2021-{new Date().getFullYear()} Fatih Aygün. MIT License.
 			</p>
 
 			<p>


### PR DESCRIPTION
Hi, please consider this PR for the Copyright year that was hard coded to 2021. This PR would remove the necessity to modify the year for every new year.

I am also open to work on more Javascript and especially Frontend issues or contributions, feel free to let me know!