### PR TITLE
Update Cloudflare D1 example for Miniflare v2.12

### DIFF
--- a/website/src/routes/_site/guide/cloudflare-workers.page.mdx
+++ b/website/src/routes/_site/guide/cloudflare-workers.page.mdx
@@ -51,7 +51,7 @@ For example, to simulate a D1 database with the binding `CLOUDFLARE_DB` during d
 // src/entry-node.ts
 import { createMiddleware } from "rakkasjs/node-adapter";
 import hattipHandler from "./entry-hattip";
-import { BetaDatabase } from "@miniflare/d1";
+import { D1Database, D1DatabaseAPI } from "@miniflare/d1";
 import { createSQLiteDB } from "@miniflare/shared";
 import fs from "fs";
 
@@ -59,7 +59,7 @@ fs.mkdirSync("./data", { recursive: true });
 
 const dbPromise = Promise.resolve()
 	.then(() => createSQLiteDB("./data/data.db"))
-	.then((db) => new BetaDatabase(db));
+	.then((sqliteDb) => new D1Database(new D1DatabaseAPI(sqliteDb)));
 
 export default createMiddleware(async (context) => {
 	const db = await dbPromise;


### PR DESCRIPTION
It looks like Cloudflare recently refactored the integration between their Wrangler and Miniflare D1 tools.

I think the change was introduced in Miniflare 2.12.0 here: https://github.com/cloudflare/miniflare/pull/480

This change fixed my `entry-node.ts` for testing/development mode using Miniflare v2.12.1:

https://github.com/patdx/edge-cms/commit/9c40e1aaaed835e3915aa4b83165b12ae0abf5a6#diff-92da841f22f071103fd6839de1b596fc8cac0bb9679580f8a36a2ddacc052f6e

Also, here is an example of the new usage inside Wrangler CLI itself:

https://github.com/cloudflare/workers-sdk/blob/2b641765975d98e6e04342533fa088f51a96acab/packages/wrangler/src/d1/execute.tsx#L245