### PR TITLE
feat: useQuery - add enabled, initialData, placeholderData options

### DIFF
--- a/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
+++ b/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
@@ -166,10 +166,15 @@ function sendRequest(
  * @param fn The function to run on the server
  * @param options Options for the query
  */
-export const useServerSideQuery: <T>(
+export const useServerSideQuery: <
+	T,
+	Enabled extends boolean = true,
+	InitialData extends T | undefined = undefined,
+	PlaceholderData = undefined,
+>(
 	fn: ServerSideFunction<T>,
-	options?: UseServerSideQueryOptions,
-) => QueryResult<T> = useSSQImpl as any;
+	options?: UseServerSideQueryOptions<T, Enabled, InitialData, PlaceholderData>,
+) => QueryResult<T, Enabled, InitialData, PlaceholderData> = useSSQImpl as any;
 
 /**
  * Runs a piece of code on the server. The callback will always run the server.

--- a/packages/rakkasjs/src/features/run-server-side/lib-common.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-common.ts
@@ -24,7 +24,12 @@ export function useRequestContext() {
 export type ServerSideFunction<T> = (context: RequestContext) => T | Promise<T>;
 
 /** Options for {@link useServerSideQuery} */
-export interface UseServerSideQueryOptions extends UseQueryOptions {
+export interface UseServerSideQueryOptions<
+	T = unknown,
+	Enabled extends boolean = true,
+	InitialData extends T | undefined = undefined,
+	PlaceholderData = undefined,
+> extends UseQueryOptions<T, Enabled, InitialData, PlaceholderData> {
 	/** Query key. Rakkas will generate a unique key if not provided. */
 	key?: string;
 	/**

--- a/packages/rakkasjs/src/features/run-server-side/lib-server.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-server.ts
@@ -157,10 +157,15 @@ export const useFormMutation: <T>(
 	fn: (ctx: RequestContext) => any,
 ) => UseFormMutationResult<T> = useFormMutationImpl as any;
 
-export const useServerSideQuery: <T>(
+export const useServerSideQuery: <
+	T,
+	Enabled extends boolean = true,
+	InitialData extends T | undefined = undefined,
+	PlaceholderData = undefined,
+>(
 	fn: ServerSideFunction<T>,
-	options?: UseServerSideQueryOptions,
-) => QueryResult<T> = useSSQImpl as any;
+	options?: UseServerSideQueryOptions<T, Enabled, InitialData, PlaceholderData>,
+) => QueryResult<T, Enabled, InitialData, PlaceholderData> = useSSQImpl as any;
 
 export const runServerSideQuery: <T>(
 	context: RequestContext | undefined,


### PR DESCRIPTION
### What is this?
Adds 3 new options to UseQueryOptions

Some of the description is copied from https://tanstack.com/query/v4/docs/react

enabled: Set this to `false` to disable automatic refetching when the query mounts or changes query keys. To refetch the query, use the `refetch` method returned from the `useQuery` instance. When enabled is changed from `false` to `true`, the query is refetched.

initialData: There may be times when you already have the initial data for a query available in your app and can simply provide it directly to your query. If and when this is the case, you can use the config.initialData option to set the initial data for a query and skip the initial loading state!
IMPORTANT: initialData is persisted to the cache, so it is not recommended to provide placeholder, partial or incomplete data to this option and instead use placeholderData

placeholderData: Placeholder data allows a query to behave as if it already has data, similar to the initialData option, but the data is not persisted to the cache. This comes in handy for situations where you have enough partial (or fake) data to render the query successfully while the actual data is fetched in the background.

### Why we need this?

It helps to simplify conditional logic and remove duplication in situations like the following:
In this example, I want to prefill the form with data from the server, but only if formId is set.

```jsx
const MyFormContinue = ({ formId }) => {
	const { data } = useSSQ((ctx) => {
		return prisma.form.findUniqueOrThrow({
			where: {
				id: formId,
			},
		});
	});

	const form = useForm({
		defaultValues: data,
	});

	return (
		<form onSubmit={form.handleSubmit(onSubmit)}>
			<input name="name" ref={form.register()} />
			<input name="email" ref={form.register()} />
			<button type="submit">submit</button>
		</form>
	);
};

const MyFormNew = () => {
	const form = useForm();

	return (
		<form onSubmit={form.handleSubmit(onSubmit)}>
			<input name="name" ref={form.register()} />
			<input name="email" ref={form.register()} />
			<button type="submit">submit</button>
		</form>
	);
};

const MyFormWrapper = ({ formId }) => {
	if (formId) {
		return <MyForm formId={formId} />;
	} else {
		return <MyFormNew />;
	}
};
```

With this PR this can be simplified to:
```jsx
const MyForm = ({ formId }) => {
	const { data } = useSSQ(
		(ctx) => {
			return prisma.form.findUniqueOrThrow({
				where: {
					id: formId,
				},
			});
		},
		{
			placeholderData: {},
			enabled: !!formId,
		},
	);

	const form = useForm({
		defaultValues: data,
	});

	return (
		<form onSubmit={form.handleSubmit(onSubmit)}>
			<input name="name" ref={form.register()} />
			<input name="email" ref={form.register()} />
			<button type="submit">submit</button>
		</form>
	);
};
```

### Typescript:
The type of returned data is detected for every combination of these new options.
In the previous example, type of data was determined by the following conditions:
1. the return type of the server-function - Prisma.Form
2. the type of placeholderData - {}
3. enabled was set to a variable, which would in itself cause the type of data to be Prisma.Form | undefined, but because placeholderData was also provided, the type of data was set to Prisma.Form | {}

Examples:
```tsx
	const [enabled, setEnabled] = useState(false);

	// number | undefined
	const { data } = useSSQ(() => 2, {
		enabled,
	});

	// number
	const { data } = useSSQ(() => 2, {
		enabled,
		placeholderData: 123,
	});

	// string | number
	const { data } = useSSQ(() => 2, {
		enabled,
		placeholderData: "123",
	});

	// number
	const { data } = useSSQ(() => 2, {
		enabled,
		initialData: 123,
	});

	// number | undefined
	const { data } = useSSQ(() => 2, {
		enabled,
		initialData: "123", // Error: Type 'string' is not assignable to type 'number'.
	});

	// number
	const { data } = useSSQ(() => 2, {
		enabled,
		initialData: 123,
		placeholderData: "456", // this is ignored if initialData is set
	});

	// string | number
	const { data } = useSSQ(() => 2, {
		placeholderData: "456", // this skips suspense even without enabled: false
	});

	// number
	const { data } = useSSQ(() => 2, {
		initialData: 123, // this skips suspense even without enabled: false
	});
```

### Suspense
If `placeholderData/initialData` is set(not undefined), suspense is skipped. The data will be fetched without suspending when the query mounts.

If `enabled` is set to false, suspense is skipped and the type of data is detected in the following order:
0. T | undefined (because it can be undefined if the data is not in the cache)
1. if initialData is set, then T (because initialData can only be T | undefined)
2. if initialData is not set and placeholderData is set, then type of placeholderData | T (because placeholderData can be of any type, this is because it isn't persisted in the cache, so it can't affect other observers of the same key)

The data will be fetched without suspending when enabled changes from false to true.


Edit: 
- Fixed enabled: !import.meta.env.SSR usage
- Fixed some types