### PR TITLE
fix: race condition when invalidating queries

### DIFF
--- a/packages/rakkasjs/src/features/use-query/client-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/client-hooks.tsx
@@ -84,8 +84,6 @@ const cache: QueryCache = {
 				cacheTime: Math.max(queryCache[key]!.cacheTime, cacheTime),
 			};
 
-			delete queryCache[key]!.invalid;
-
 			valueOrPromise.then(
 				(value) => {
 					queryCache[key] = {
@@ -94,6 +92,7 @@ const cache: QueryCache = {
 						hydrated: false,
 						date: Date.now(),
 					};
+					delete queryCache[key]!.invalid;
 					delete queryCache[key]!.promise;
 
 					queryCache[key]!.subscribers.forEach((subscriber) => subscriber());


### PR DESCRIPTION
There was race condition when invalidating a query before it finished refetching
useEffect in useQueryBase was stuck with invalid = true

So if you keep pressing the "invalidate" button, invalid=true becomes stuck, and the query won't refetch anymore.