### PR TITLE
fix: bugs related to enabled: false

### DIFF
--- a/packages/rakkasjs/src/features/use-query/implementation.ts
+++ b/packages/rakkasjs/src/features/use-query/implementation.ts
@@ -267,6 +267,7 @@ function useQueryBase<T>(
 		placeholderData,
 	} = options;
 
+	const [initialEnabled] = useState(enabled);
 	const cache = useContext(QueryCacheContext);
 
 	const item = useSyncExternalStore(
@@ -295,6 +296,7 @@ function useQueryBase<T>(
 		}
 
 		if (
+			enabled &&
 			(cacheItem.invalid ||
 				(refetchOnMount &&
 					(refetchOnMount === "always" ||
@@ -340,7 +342,10 @@ function useQueryBase<T>(
 		});
 	}
 
-	if (initialData === undefined && placeholderData !== undefined) {
+	if (
+		initialData === undefined &&
+		(placeholderData !== undefined || !initialEnabled)
+	) {
 		return Object.assign(queryResultReference, {
 			data: placeholderData,
 			isRefetching: enabled,


### PR DESCRIPTION
Don't refetch when invalidating a disabled query
Don't suspend when the initial state of enabled is false and changes to true