### PR TITLE
feat: add support for link tags in head

### DIFF
--- a/packages/rakkasjs/src/features/head/lib.tsx
+++ b/packages/rakkasjs/src/features/head/lib.tsx
@@ -6,6 +6,8 @@ export type HeadProps = Record<
 	string,
 	string | Record<string, string> | null
 > & {
+	tagName?: "meta" | "title" | "link";
+
 	// Special cases
 	charset?: string;
 	title?: string;
@@ -64,18 +66,14 @@ export function Head(props: HeadProps): ReactElement {
 	} else {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		useEffect(() => {
-			const old: HeadProps = {};
 			for (const [name, value] of Object.entries(props)) {
-				if (name in tags) {
-					old[name] = tags[name];
-				}
 				tags[name] = value;
 			}
 
 			scheduleHeadUpdate();
 			return () => {
-				for (const [name, value] of Object.entries(old)) {
-					tags[name] = value;
+				for (const name of Object.keys(props)) {
+					delete tags[name];
 				}
 				scheduleHeadUpdate();
 			};

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -285,8 +285,8 @@ export async function loadRoute(
 						!import.meta.env.SSR &&
 						i === (window as any).$RAKKAS_ACTION_ERROR_INDEX
 					) {
-						throw new Error("Action error");
 						delete (window as any).$RAKKAS_ACTION_ERROR_INDEX;
+						throw new Error("Action error");
 					}
 					const preloaded =
 						ssrPreloaded?.[i] ?? (await preload?.(preloadContext));

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -988,6 +988,17 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 			const r2 = await fetch(host + "/dev-only", { method: "POST" });
 			expect(r2.status).toBe(dev ? 200 : 404);
 		});
+
+		test("sets head tags", async () => {
+			const r = await fetch(host + "/head");
+			const text = await r.text();
+			expect(text).toContain(
+				'<meta charset="utf-8">' +
+					'<meta name="viewport" content="width=device-width, initial-scale=1">' +
+					"<title>The head page</title>" +
+					'<link rel="canonical" href="http://localhost:3000/head" data-rh="canonical">',
+			);
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/src/routes/head/_head.page.tsx
+++ b/testbed/kitchen-sink/src/routes/head/_head.page.tsx
@@ -1,0 +1,16 @@
+import type { Page } from "rakkasjs";
+
+const HeadPage: Page = () => <p>Check my head tags!</p>;
+
+export default HeadPage;
+
+HeadPage.preload = () => ({
+	head: {
+		title: "The head page",
+		canonical: {
+			tagName: "link",
+			rel: "canonical",
+			href: "http://localhost:3000/head",
+		},
+	},
+});

--- a/website/src/routes/_site/guide/pages-and-basics.page.mdx
+++ b/website/src/routes/_site/guide/pages-and-basics.page.mdx
@@ -20,7 +20,7 @@ A very simple Rakkas page would look like this:
 
 ## `Head` component
 
-Rakkas provides a `Head` component for managing the title and meta tags in the document head:
+Rakkas provides a `Head` component for managing the title, meta, and link tags in the document head:
 
 ```jsx
 <Head
@@ -29,7 +29,7 @@ Rakkas provides a `Head` component for managing the title and meta tags in the d
 	description="About page" // <meta name="description" content="About page" />
 	og:image="https://example.com/image.jpg" // <meta property="og:image" content="https://example.com/image.jpg" />
 	refresh={{ "http-equiv": "refresh", content: "5" }} // <meta http-equiv="refresh" content="5" />
-
+	canonical={{ tagName: "link", rel: "canonical", href: "https://example.com/about" }} // <link rel="canonical" href="https://example.com/about" />
 >
 ```
 


### PR DESCRIPTION
Usage example:

```ts
import type { Page } from "rakkasjs";

const HeadPage: Page = () => <p>Check my head tags!</p>;

export default HeadPage;

HeadPage.preload = () => ({
  head: {
    title: "The head page",
    canonical: {
      tagName: "link",
      rel: "canonical",
      href: "http://localhost:3000/head",
    },
  },
});
```
