### PR TITLE
fix: don't crash when a server-side function is not used

### DIFF
--- a/packages/rakkasjs/src/features/run-server-side/lib-server.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-server.ts
@@ -22,6 +22,10 @@ function runSSQImpl(
 		fn: (...args: any) => any,
 	],
 ): Promise<any> {
+	if (typeof desc === "function") {
+		return Promise.reject(new Error("runSSQ call hasn't been transformed"));
+	}
+
 	const [moduleId, counter, closure, fn] = desc;
 
 	const stringified = closure.map((x) => stringify(x));
@@ -63,6 +67,10 @@ function useSSQImpl(
 	],
 	options: UseServerSideQueryOptions = {},
 ): QueryResult<any> {
+	if (typeof desc === "function") {
+		throw new Error("useSSQ call hasn't been transformed");
+	}
+
 	const { key: userKey, usePostMethod, ...useQueryOptions } = options;
 	const ctx = useRequestContext();
 	const [moduleId, counter, closure, fn] = desc;

--- a/packages/rakkasjs/src/features/run-server-side/vite-plugin.ts
+++ b/packages/rakkasjs/src/features/run-server-side/vite-plugin.ts
@@ -81,11 +81,15 @@ export default function runServerSide(): PluginOption[] {
 						moduleId = (idCounter++).toString(36);
 					}
 
-					plugins.push(
-						options?.ssr
-							? babelTransformServerSideHooks(moduleId)
-							: babelTransformClientSideHooks(moduleId, ref),
-					);
+					// moduleId can be undefined if the file is not in the manifest
+					// e.g. if it hasn't been used. We can safely ignore it in that case.
+					if (moduleId) {
+						plugins.push(
+							options?.ssr
+								? babelTransformServerSideHooks(moduleId)
+								: babelTransformClientSideHooks(moduleId, ref),
+						);
+					}
 				}
 
 				if (!plugins.length) {


### PR DESCRIPTION
When a module containing a server-side function (`useSSQ` etc.) is never used on the client, it can't be found in the module manifest, causing the build to fail. This PR fixes it by skipping the transform in such cases. Attempting to call an untransformed `runSSQ` or `useSSQ` will throw an error. `runSSM` cannot be called on the server anyway.