### PR TITLE
fix: 404 and page guard interaction

### DIFF
--- a/packages/rakkasjs/src/features/pages/middleware.tsx
+++ b/packages/rakkasjs/src/features/pages/middleware.tsx
@@ -44,7 +44,9 @@ export default async function renderPageRoute(
 
 	const pageHooks = ctx.hooks.map((hook) => hook.createPageHooks?.(ctx));
 
-	const routes = (await import("virtual:rakkasjs:server-page-routes")).default;
+	const { default: routes, notFoundRoutes } = await import(
+		"virtual:rakkasjs:server-page-routes"
+	);
 
 	let {
 		url: { pathname },
@@ -87,7 +89,7 @@ export default async function renderPageRoute(
 				pathname += "/";
 			}
 
-			found = findPage(routes, pathname + "%24404");
+			found = findPage(notFoundRoutes, pathname + "%24404");
 			if (found) {
 				break;
 			}

--- a/packages/rakkasjs/src/features/pages/vite-plugin.ts
+++ b/packages/rakkasjs/src/features/pages/vite-plugin.ts
@@ -139,7 +139,8 @@ export default function pageRoutes(options: PageRoutesOptions = {}): Plugin[] {
 			guardedPageIndices.add(pageIndex);
 		}
 
-		let exportStatement = "export default [\n";
+		let routesExport = "export default [\n";
+		let notFoundExport = "export const notFoundRoutes = [\n";
 
 		const pageRoutes = sortRoutes(
 			pageFiles.map((endpointFile, i) => {
@@ -189,10 +190,15 @@ export default function pageRoutes(options: PageRoutesOptions = {}): Plugin[] {
 
 			exportElement += "],\n";
 
-			exportStatement += exportElement;
+			if (baseName === "$404" || baseName.endsWith("/$404")) {
+				notFoundExport += exportElement;
+			} else {
+				routesExport += exportElement;
+			}
 		}
 
-		exportStatement += "]";
+		routesExport += "]";
+		notFoundExport += "]";
 
 		const out = [
 			layoutImporters,
@@ -201,7 +207,8 @@ export default function pageRoutes(options: PageRoutesOptions = {}): Plugin[] {
 			guardImporters,
 			singlePageGuardImporters,
 			pageNames,
-			exportStatement,
+			routesExport,
+			notFoundExport,
 		]
 			.filter(Boolean)
 			.join("\n");
@@ -224,13 +231,13 @@ export default function pageRoutes(options: PageRoutesOptions = {}): Plugin[] {
 			async load(id, options) {
 				if (id === "virtual:rakkasjs:server-page-routes") {
 					if (!options?.ssr) {
-						return "export default null";
+						return "export default null; export const notFoundRoutes = null;";
 					}
 
 					return generateRoutesModule();
 				} else if (id === "virtual:rakkasjs:client-page-routes") {
 					if (options?.ssr) {
-						return "export default null";
+						return "export default null; export const notFoundRoutes = null;";
 					}
 
 					return generateRoutesModule(true);

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -86,7 +86,15 @@ export function createRequestHandler(userHooks: ServerHooks = {}) {
 
 			hooks.map((hook) => hook.middleware?.beforeNotFound).flat(),
 			notFound,
-			renderPageRoute,
+			async (ctx: RequestContext) => {
+				try {
+					return await renderPageRoute(ctx);
+				} catch (error) {
+					if (!process.env.RAKKAS_PRERENDER) {
+						console.error(error);
+					}
+				}
+			},
 		].flat(),
 	);
 }

--- a/packages/rakkasjs/src/runtime/virtual-modules.d.ts
+++ b/packages/rakkasjs/src/runtime/virtual-modules.d.ts
@@ -41,6 +41,7 @@ declare module "virtual:rakkasjs:server-page-routes" {
 	>;
 
 	export default routes;
+	export const notFoundRoutes: typeof routes;
 }
 
 declare module "virtual:rakkasjs:client-page-routes" {
@@ -64,6 +65,7 @@ declare module "virtual:rakkasjs:client-page-routes" {
 	type LayoutModule = import("./page-types").LayoutModule;
 
 	export default routes;
+	export const notFoundRoutes: typeof routes;
 }
 
 declare module "virtual:rakkasjs:client-manifest" {

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -999,6 +999,12 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 					'<link rel="canonical" href="http://localhost:3000/head" data-rh="canonical">',
 			);
 		});
+
+		test("disables guarded catch-all route", async () => {
+			const r = await fetch(host + "/guarded-catch-all");
+			const text = await r.text();
+			expect(text).not.toContain("I shouldn&#x27;t be here!");
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/src/routes/guarded-catch-all/$404.page.tsx
+++ b/testbed/kitchen-sink/src/routes/guarded-catch-all/$404.page.tsx
@@ -1,0 +1,8 @@
+export default function GuardedNotFoundPage() {
+	return (
+		<div>
+			<h1>404</h1>
+			<p>Page not found, but it's good.</p>
+		</div>
+	);
+}

--- a/testbed/kitchen-sink/src/routes/guarded-catch-all/[...path].guard.ts
+++ b/testbed/kitchen-sink/src/routes/guarded-catch-all/[...path].guard.ts
@@ -1,0 +1,3 @@
+import { PageRouteGuard } from "rakkasjs";
+
+export const pageGuard: PageRouteGuard = () => false;

--- a/testbed/kitchen-sink/src/routes/guarded-catch-all/[...path].page.tsx
+++ b/testbed/kitchen-sink/src/routes/guarded-catch-all/[...path].page.tsx
@@ -1,0 +1,3 @@
+export default function GuardedCatchAllPage() {
+	return <h1>I shouldn't be here!</h1>;
+}

--- a/website/src/routes/_site/guide/404-handling.page.mdx
+++ b/website/src/routes/_site/guide/404-handling.page.mdx
@@ -2,8 +2,10 @@
 title: 404 handling
 ---
 
-When Rakkas fails to match a URL with a page component, it will look for a `$404.page.jsx` (or `.tsx`) file. For instance, when a request to `/` is made and no page component matches, Rakkas will look for `/foo/bar/baz/$404`, `/foo/bar/$404`, `/foo/$404`, and `/$404` in that order. This way, 404 pages can have the correct layout depending on the URL.
+When Rakkas fails to match a URL with a page component, it will look for a `$404.page.jsx` (or `.tsx`) file. For instance, when a request to `/foo/bar/baz` is made and no page component matches, Rakkas will look for `/foo/bar/baz/$404`, `/foo/bar/$404`, `/foo/$404`, and `/$404` in that order. This way, 404 pages can have the correct layout depending on the URL.
 
 404 pages can have `action`, `headers`, `prerender`, and `preload` functions just like normal pages. It's good practice to always have a root 404 page in `src/routes/$404.page.jsx` or `.tsx`, Rakkas's default 404 page is very basic unstyled.
 
-If a `Link` or `StyledLink` component points to a non-existent page, Rakkas will do a full page reload before showing a 404 page just in case the URL is pointing to a static asset.
+The difference between using a 404 page and a catch-all page with spread parameters, that is betweebn `/path/$404` and `/path/[...rest]` is that 404 pages have lower priority. A catch-all page route will match before any API routes, but a 404 page will only match if no other route matches.
+
+If a `Link` or `StyledLink` component points to a non-existent page, Rakkas will do a full page reload before showing a 404 page just in case the URL is pointing to a non-page route like an API endpoint or a static file.

--- a/website/src/routes/_site/guide/dynamic-routes.page.mdx
+++ b/website/src/routes/_site/guide/dynamic-routes.page.mdx
@@ -14,6 +14,8 @@ You can use more than one dynamic parameter like `/user/[userName]/posts/[postId
 
 More specific routes have priority over generic ones, so you can have both `/products/list` for a specific match and `/products/[productId]` as a catch-all route.
 
-### Spread parameters
+## Spread parameters and catch-all routes
 
 You can use the `[...paramName]` syntax to match more than one segment at the end of a route. For instance, `/path/[...rest]` will match `/path/aaa/bbb/ccc/` with `params: { rest: "/aaa/bbb/ccc" }`, `/path` with `params: { rest: "" }`, and `/path/` with `params: { rest: "/" }`.
+
+> **NOTE:** Catch-all page routes have higher priority than [API routes](/guide/api-routes) which means a catch-all page route will be matched before an API route is matched even if the latter is more specific. For example, `/foo/[...slug].page.tsx` will match `/foo/bar` before an API route `/foo/bar.api.ts` is matched. You can use a [route guard](/guide/route-guards#catch-all) to disable the page route for a specific path to make it work.

--- a/website/src/routes/_site/guide/pages-and-basics.page.mdx
+++ b/website/src/routes/_site/guide/pages-and-basics.page.mdx
@@ -37,6 +37,6 @@ The format is inspired by [Remix `meta` function](https://remix.run/docs/en/v1/r
 
 ## Fast refresh
 
-Rakkas supports Fast Refresh which allows you to edit your components and get immediate feedback for your changes without having to reload the page. Function components will be updated without losing their state (class components will lose their state). If you open one of the examples above in CodeSandbox and edit a file, the changes will be instantly reflected in the preview.
+Rakkas supports Fast Refresh which allows you to edit your components and get immediate feedback for your changes without having to reload the page. Function components will be updated without losing their state (class components will lose their state). If you open one of the examples above and edit a file, the changes will be instantly reflected in the preview.
 
 Fast Refresh only works on files that only export React components. Exporting any other value will fall back to a full reload. Exporting types is OK.

--- a/website/src/routes/_site/guide/route-guards.page.mdx
+++ b/website/src/routes/_site/guide/route-guards.page.mdx
@@ -18,3 +18,16 @@ Rakkas's solution to such requirements is called route guards. A route guard is 
 The rewrite feature is handy, for example, to redirect to a login form while remembering the original URL.
 
 A route guard can also guard all pages under a directory if it's named `$guard.js` (or `.ts`). Guards are called starting from the outermost one. All have to return true for the page to render.
+
+## Disabling catch-all page routes <a id="catch-all" />
+
+Another use case for route guards is to disable catch-all page routes that shadow API routes. For example, `/foo/[...slug].page.tsx` will match `/foo/bar` before an API route `/foo/bar.api.ts` is matched, effectively shadowing it. To prevent this, you can create a guard file `foo/[...slug].guard.ts` with the following content:
+
+```ts
+import type { LookupHookResult, PageContext } from "rakkasjs";
+
+export function pageGuard(ctx: PageContext): LookupHookResult {
+	// Selectively disable the catch-all page route for /foo/bar
+	return ctx.url.pathname !== "/foo/bar";
+}
+```


### PR DESCRIPTION
This PR improves 404 handling for pages and fixes an issue causing guarded catch-all routes to be matched before 404 pages.