### PR TITLE
fix: process data routes before page routes

### DIFF
--- a/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
+++ b/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
@@ -8,7 +8,7 @@ import { EventStreamContentType } from "@microsoft/fetch-event-source";
 
 const runServerSideServerHooks: ServerHooks = {
 	middleware: {
-		beforeApiRoutes: async (ctx) => {
+		beforePages: async (ctx) => {
 			const prefix = `/_data/`;
 			let action = ctx.url.searchParams.get("_action");
 


### PR DESCRIPTION
This PR changes the priority of `_data` routes so that they come before page routes instead of coming between page routes and API routes.

This fixes a potential bug where a page guard can prevent a `_data` route from being accessed.