### PR TITLE
fix: run user server hooks before builtin ones

### DIFF
--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -61,7 +61,7 @@ export interface PageRequestHooks {
  * handler and fefault export it from your HatTip entry.
  */
 export function createRequestHandler(userHooks: ServerHooks = {}) {
-	const hooks = [...serverHooks, userHooks];
+	const hooks = [userHooks, ...serverHooks];
 
 	return compose(
 		[


### PR DESCRIPTION
This PR allows running user server hooks to run before builtin ones so that session and similar middleware can run before `_data` routes.