### PR TITLE
fix: don't die catastrophically when a refetch fails

### DIFF
--- a/packages/rakkasjs/src/features/use-query/client-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/client-hooks.tsx
@@ -84,8 +84,8 @@ const cache: QueryCache = {
 				cacheTime: Math.max(queryCache[key]!.cacheTime, cacheTime),
 			};
 
-			valueOrPromise.then(
-				(value) => {
+			valueOrPromise
+				.then((value) => {
 					queryCache[key] = {
 						...queryCache[key]!,
 						value,
@@ -94,15 +94,15 @@ const cache: QueryCache = {
 					};
 					delete queryCache[key]!.invalid;
 					delete queryCache[key]!.promise;
-
-					queryCache[key]!.subscribers.forEach((subscriber) => subscriber());
-				},
-				(error) => {
+				})
+				.catch((error) => {
+					queryCache[key] = { ...queryCache[key]!, error };
 					delete queryCache[key]!.promise;
-					queryCache[key]!.error = error;
 					throw error;
-				},
-			);
+				})
+				.finally(() => {
+					queryCache[key]!.subscribers.forEach((subscriber) => subscriber());
+				});
 		} else {
 			queryCache[key] ||= {
 				date: Date.now(),

--- a/packages/rakkasjs/src/features/use-query/implementation.ts
+++ b/packages/rakkasjs/src/features/use-query/implementation.ts
@@ -344,19 +344,19 @@ function useQueryBase<T>(
 		return;
 	}
 
-	if (!import.meta.env.SSR && item && "error" in item) {
-		const error = item.error;
-
-		throw error;
-	}
-
 	if (item && "value" in item) {
 		return Object.assign(queryResultReference, {
 			data: item.value,
 			isRefetching: !!item.promise,
 			refetch,
 			dataUpdatedAt: item.date,
+			error: item.error,
 		});
+	}
+
+	if (!import.meta.env.SSR && item && "error" in item) {
+		const error = item.error;
+		throw error;
 	}
 
 	if (
@@ -431,6 +431,8 @@ export interface QueryResult<
 	isRefetching: boolean;
 	/** Update date of the last returned data */
 	dataUpdatedAt?: number;
+	/** Error thrown by the query when a refetch fails */
+	error?: any;
 }
 
 export interface EventSourceResult<T> {


### PR DESCRIPTION
When a query fails to refetch when using `useQuery` and friends, it will now keep returning the last successful data along with the last thrown error instead of throwing during render which triggers an error boundary.

This might not be always desirable but it's easier to just throw the returned error to get the old behavior than to ignore refetch errors.

Old behavior caused bad UX like showing an error (instead of data) on network disconnections or errors. It's better to hold the last fetched data along with an error indicator.