### PR TITLE
feat: allow non-ascii chars in routes and -- for flat routes

### DIFF
--- a/packages/rakkasjs/src/features/pages/middleware.tsx
+++ b/packages/rakkasjs/src/features/pages/middleware.tsx
@@ -89,7 +89,7 @@ export default async function renderPageRoute(
 				pathname += "/";
 			}
 
-			found = findPage(notFoundRoutes, pathname + "%24404");
+			found = findPage(notFoundRoutes, pathname + "$404");
 			if (found) {
 				break;
 			}

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -239,9 +239,9 @@ export async function loadRoute(
 				pathname += "/";
 			}
 
-			const result = findPage(notFoundRoutes, pathname + "%24404");
+			const result = findPage(notFoundRoutes, pathname + "$404");
 			if (import.meta.hot && !result) {
-				findPage(updatedNotFoundRoutes!, pathname + "%24404");
+				findPage(updatedNotFoundRoutes!, pathname + "$404");
 			}
 
 			found = result;

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1019,6 +1019,18 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 			const text = await r.text();
 			expect(text).not.toContain("I shouldn&#x27;t be here!");
 		});
+
+		test("matches non-ascii paths", async () => {
+			const r = await fetch(host + "/non-ascii/😀");
+			const text = await r.text();
+			expect(text).toContain("😀");
+		});
+
+		test("matches -- for /", async () => {
+			const r = await fetch(host + "/flat/route");
+			const text = await r.text();
+			expect(text).toContain("Flat Route");
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/src/routes/flat--route.page.tsx
+++ b/testbed/kitchen-sink/src/routes/flat--route.page.tsx
@@ -1,0 +1,3 @@
+export default function FlatRoutePage() {
+	return <h1>Flat Route</h1>;
+}

--- a/testbed/kitchen-sink/src/routes/non-ascii/@[canrau].page.tsx
+++ b/testbed/kitchen-sink/src/routes/non-ascii/@[canrau].page.tsx
@@ -1,0 +1,5 @@
+import { PageProps } from "rakkasjs";
+
+export default function CanRauPage(props: PageProps<{ canrau: string }>) {
+	return <h1>Can Rau's user: {props.params.canrau}</h1>;
+}

--- a/testbed/kitchen-sink/src/routes/non-ascii/😀.page.tsx
+++ b/testbed/kitchen-sink/src/routes/non-ascii/😀.page.tsx
@@ -1,0 +1,3 @@
+export default function SmileyPage() {
+	return <h1>😀</h1>;
+}


### PR DESCRIPTION
This PR adds support for non-ASCII characters in routes and the use of `--` for flat routes.