### PR TITLE
feat: Stable deploys

### DIFF
--- a/packages/rakkasjs/src/features/run-server-side/implementation/transform/transform-utils.ts
+++ b/packages/rakkasjs/src/features/run-server-side/implementation/transform/transform-utils.ts
@@ -100,3 +100,31 @@ export function removeUnreferenced(
 		if (!removed) break;
 	}
 }
+
+export function extractUniqueId(optionsPath: NodePath): string | undefined {
+	if (!optionsPath.isObjectExpression()) {
+		throw optionsPath.buildCodeFrameError(
+			"The `options` argument must be a literal object",
+		);
+	}
+
+	const stableIdPath = optionsPath.get("properties").find(
+		(prop) =>
+			(prop.get("key") as NodePath<t.Identifier>)?.isIdentifier({
+				name: "uniqueId",
+			}),
+	);
+
+	if (!stableIdPath) {
+		return;
+	}
+
+	const value: NodePath = stableIdPath.get("value") as NodePath;
+	if (!value.isStringLiteral()) {
+		throw value.buildCodeFrameError(
+			"The `uniqueId` property of the `options` argument must be a string literal",
+		);
+	}
+
+	return value.node.value;
+}

--- a/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
+++ b/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
@@ -97,9 +97,10 @@ function sendRequest(
 	vars?: any,
 ) {
 	let response: Promise<Response>;
+	const prefix = "_app/data/";
 
 	if (usePostMethod) {
-		response = fetch("/_app/data/" + callSiteId, {
+		response = fetch(prefix + callSiteId, {
 			method: "POST",
 			body:
 				"[[" +
@@ -115,7 +116,7 @@ function sendRequest(
 		let closurePath = stringified.map(encodeFileNameSafe).join("/");
 		if (closurePath) closurePath = "/" + closurePath;
 
-		response = fetch("/_app/data/" + callSiteId + closurePath + "/d.js");
+		response = fetch(prefix + callSiteId + closurePath + "/d.js");
 	}
 
 	return response.then(async (r) => {

--- a/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
+++ b/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
@@ -58,7 +58,7 @@ function useSSEImpl(
 	let closurePath = stringified.map(encodeFileNameSafe).join("/");
 	if (closurePath) closurePath = "/" + closurePath;
 
-	const url = "/_data/" + callSiteId + closurePath + "/d.js";
+	const url = "/_app/data/" + callSiteId + closurePath + "/d.js";
 
 	return useEventSource(url);
 }
@@ -99,7 +99,7 @@ function sendRequest(
 	let response: Promise<Response>;
 
 	if (usePostMethod) {
-		response = fetch("/_data/" + callSiteId, {
+		response = fetch("/_app/data/" + callSiteId, {
 			method: "POST",
 			body:
 				"[[" +
@@ -115,7 +115,7 @@ function sendRequest(
 		let closurePath = stringified.map(encodeFileNameSafe).join("/");
 		if (closurePath) closurePath = "/" + closurePath;
 
-		response = fetch("/_data/" + callSiteId + closurePath + "/d.js");
+		response = fetch("/_app/data/" + callSiteId + closurePath + "/d.js");
 	}
 
 	return response.then(async (r) => {

--- a/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
+++ b/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
@@ -1,10 +1,13 @@
 import { QueryResult, useQuery } from "../use-query/lib";
 import { stringify } from "@brillout/json-serializer/stringify";
 import {
+	RunServerSideMutationOptions,
+	RunServerSideQueryOptions,
 	ServerSideFunction,
 	useFormAction,
 	UseFormMutationFn,
 	UseFormMutationResult,
+	UseServerSideMutationOptions,
 	UseServerSideQueryOptions,
 } from "./lib-common";
 import type { RequestContext } from "@hattip/compose";
@@ -19,64 +22,56 @@ import { EventSourceResult, useEventSource } from "../use-query/implementation";
 
 function runSSQImpl(
 	_: RequestContext,
-	desc: [moduleId: string, counter: number, closure: any[]],
+	desc: [callSiteId: string, closure: any[]],
 	usePostMethod = false,
 ): any {
-	const [moduleId, counter, closure] = desc;
+	const [callSiteId, closure] = desc;
 
 	const stringified = closure.map((x) => stringify(x));
 
-	return sendRequest(moduleId, counter, stringified, usePostMethod);
+	return sendRequest(callSiteId, stringified, usePostMethod);
 }
 
 function useSSQImpl(
-	desc: [moduleId: string, counter: number, closure: any[]],
+	desc: [callSiteId: string, closure: any[]],
 	options: UseServerSideQueryOptions = {},
 ): QueryResult<any> {
-	const [moduleId, counter, closure] = desc;
+	const [callSiteId, closure] = desc;
 	const { key: userKey, usePostMethod = false, ...useQueryOptions } = options;
 
 	const stringified = closure.map((x) => stringify(x));
-	const key = userKey ?? `$ss:${moduleId}:${counter}:${stringified}`;
+	const key = userKey ?? `$ss:${callSiteId}:${stringified}`;
 
 	return useQuery(
 		key,
-		() => sendRequest(moduleId, counter, stringified, usePostMethod),
+		() => sendRequest(callSiteId, stringified, usePostMethod),
 		useQueryOptions,
 	);
 }
 
 function useSSEImpl(
-	desc: [moduleId: string, counter: number, closure: any[]],
+	desc: [callSiteId: string, closure: any[]],
 ): EventSourceResult<any> {
-	const [moduleId, counter, closure] = desc;
+	const [callSiteId, closure] = desc;
 
 	const stringified = closure.map((x) => stringify(x));
 	let closurePath = stringified.map(encodeFileNameSafe).join("/");
 	if (closurePath) closurePath = "/" + closurePath;
 
-	const url =
-		`/_data/${import.meta.env.RAKKAS_BUILD_ID}/` +
-		encodeURIComponent(moduleId) +
-		"/" +
-		counter +
-		closurePath +
-		"/d.js";
+	const url = "/_data/" + callSiteId + closurePath + "/d.js";
 
 	return useEventSource(url);
 }
 
-function runSSMImpl(
-	desc: [moduleId: string, counter: number, closure: any[], vars?: any],
-) {
-	const [moduleId, counter, closure, vars] = desc;
+function runSSMImpl(desc: [callSiteId: string, closure: any[], vars?: any]) {
+	const [callSiteId, closure, vars] = desc;
 	const stringified = closure.map((x) => stringify(x));
 
-	return sendRequest(moduleId, counter, stringified, true, vars);
+	return sendRequest(callSiteId, stringified, true, vars);
 }
 
 function useFormMutationImpl<T>(
-	desc: [moduleId: string, counter: number, closure: any[]],
+	desc: [callSiteId: string, closure: any[]],
 	options?: UseMutationOptions<T, any>,
 ): UseFormMutationResult<T> {
 	const action = useFormAction(desc).href;
@@ -89,15 +84,14 @@ function useFormMutationImpl<T>(
 }
 
 function useSSMImpl(
-	desc: [moduleId: string, counter: number, closure: any[]],
+	desc: [callSiteId: string, closure: any[]],
 	options?: UseMutationOptions<any, any>,
 ) {
 	return useMutation((vars) => runSSMImpl([...desc, vars]), options);
 }
 
 function sendRequest(
-	moduleId: string,
-	counter: number,
+	callSiteId: string,
 	stringified: string[],
 	usePostMethod: boolean,
 	vars?: any,
@@ -105,36 +99,23 @@ function sendRequest(
 	let response: Promise<Response>;
 
 	if (usePostMethod) {
-		response = fetch(
-			`/_data/${import.meta.env.RAKKAS_BUILD_ID}/` +
-				encodeURIComponent(moduleId) +
-				"/" +
-				counter,
-			{
-				method: "POST",
-				body:
-					"[[" +
-					stringified.join(",") +
-					"]" +
-					(vars !== undefined ? "," + stringify(vars) : "") +
-					"]",
-				headers: {
-					"Content-Type": "application/json",
-				},
+		response = fetch("/_data/" + callSiteId, {
+			method: "POST",
+			body:
+				"[[" +
+				stringified.join(",") +
+				"]" +
+				(vars !== undefined ? "," + stringify(vars) : "") +
+				"]",
+			headers: {
+				"Content-Type": "application/json",
 			},
-		);
+		});
 	} else {
 		let closurePath = stringified.map(encodeFileNameSafe).join("/");
 		if (closurePath) closurePath = "/" + closurePath;
 
-		response = fetch(
-			`/_data/${import.meta.env.RAKKAS_BUILD_ID}/` +
-				encodeURIComponent(moduleId) +
-				"/" +
-				counter +
-				closurePath +
-				"/d.js",
-		);
+		response = fetch("/_data/" + callSiteId + closurePath + "/d.js");
 	}
 
 	return response.then(async (r) => {
@@ -188,6 +169,7 @@ export const useServerSideQuery: <
 export const runServerSideQuery: <T>(
 	context: RequestContext | undefined,
 	fn: ServerSideFunction<T>,
+	options?: RunServerSideQueryOptions,
 ) => Promise<T> = runSSQImpl as any;
 
 /**
@@ -201,6 +183,7 @@ export const runServerSideQuery: <T>(
  */
 export const runServerSideMutation: <T>(
 	fn: ServerSideFunction<T>,
+	options?: RunServerSideMutationOptions,
 ) => Promise<T> = runSSMImpl as any;
 
 /**
@@ -214,12 +197,12 @@ export const runServerSideMutation: <T>(
  */
 export const useServerSideMutation: <T, V = void>(
 	fn: (context: RequestContext, vars: V) => T | Promise<T>,
-	options?: UseMutationOptions<T, V>,
+	options?: UseServerSideMutationOptions<T, V>,
 ) => UseMutationResult<T, V> = useSSMImpl as any;
 
 export const useFormMutation: <T>(
 	fn: UseFormMutationFn<T>,
-	options?: UseMutationOptions<T, void>,
+	options?: UseServerSideMutationOptions<T, void>,
 ) => UseFormMutationResult<T> = useFormMutationImpl as any;
 
 export const useServerSentEvents: <T>(

--- a/packages/rakkasjs/src/features/run-server-side/lib-common.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-common.ts
@@ -6,6 +6,7 @@ import {
 	UseMutationErrorResult,
 	UseMutationIdleResult,
 	UseMutationLoadingResult,
+	UseMutationOptions,
 	UseMutationSuccessResult,
 	usePageContext,
 } from "../../lib";
@@ -23,6 +24,31 @@ export function useRequestContext() {
 /** Callback passed to useServerSide/runServerside family of functions */
 export type ServerSideFunction<T> = (context: RequestContext) => T | Promise<T>;
 
+/** Options for {@link runServerSideQuery} */
+export interface RunServerSideQueryOptions {
+	/**
+	 * Unique ID for this query. Rakkas will generate a unique ID if not provided.
+	 * This must be a string literal that is unique across the entire application.
+	 */
+	uniqueId?: string;
+	/**
+	 * If true, a POST request will be sent instead of GET. It may be useful
+	 * when the query requires a large amount of data to be sent from the
+	 * client. The down side is that it cannot be prerendered or cached so it
+	 * shouldn't be used when rendering static pages.
+	 */
+	usePostMethod?: boolean;
+}
+
+/** Options for {@link runServerSideMutation} */
+export interface RunServerSideMutationOptions {
+	/**
+	 * Unique ID for this mutation. Rakkas will generate a unique ID if not provided.
+	 * This must be a string literal that is unique across the entire application.
+	 */
+	uniqueId?: string;
+}
+
 /** Options for {@link useServerSideQuery} */
 export interface UseServerSideQueryOptions<
 	T = unknown,
@@ -30,15 +56,30 @@ export interface UseServerSideQueryOptions<
 	InitialData extends T | undefined = undefined,
 	PlaceholderData = undefined,
 > extends UseQueryOptions<T, Enabled, InitialData, PlaceholderData> {
+	/**
+	 * Unique ID for this query. Rakkas will generate a unique ID if not provided.
+	 * This must be a string literal that is unique across the entire application.
+	 */
+	uniqueId?: string;
 	/** Query key. Rakkas will generate a unique key if not provided. */
 	key?: string;
 	/**
 	 * If true, a POST request will be sent instead of GET. It may be useful
 	 * when the query requires a large amount of data to be sent from the
-	 * client. The down side is that it cannot be prerendered so it shouldn't
-	 * be used when rendering static pages.
+	 * client. The down side is that it cannot be prerendered or cached so it
+	 * shouldn't be used when rendering static pages.
 	 */
 	usePostMethod?: boolean;
+}
+
+/** Options for {@link useServerSideMutation} */
+export interface UseServerSideMutationOptions<T = unknown, V = unknown>
+	extends UseMutationOptions<T, V> {
+	/**
+	 * Unique ID for this mutation. Rakkas will generate a unique ID if not provided.
+	 * This must be a string literal that is unique across the entire application.
+	 */
+	uniqueId?: string;
 }
 
 export type UseFormMutationResult<T> = {
@@ -55,24 +96,17 @@ export type UseFormMutationFn<T> = (
 	context: RequestContext,
 ) => ActionResult<T> | Promise<ActionResult<T>>;
 
-export function useFormAction(
-	desc: [moduleId: string, counter: number, closure: any[]],
-) {
+export function useFormAction(desc: [callSiteId: string, closure: any[]]) {
 	const { url } = usePageContext();
 
-	const [moduleId, counter, closure] = desc;
+	const [callSiteId, closure] = desc;
 	const stringified = closure.map((x) => stringify(x));
 
 	let closurePath = stringified.map(encodeFileNameSafe).join("/");
 	if (closurePath) closurePath = "/" + closurePath;
 
 	const actionPath =
-		import.meta.env.RAKKAS_BUILD_ID +
-		"/" +
-		encodeURIComponent(moduleId) +
-		"/" +
-		counter +
-		closurePath;
+		import.meta.env.RAKKAS_BUILD_ID + "/" + callSiteId + closurePath;
 	const actionUrl = new URL(url);
 	actionUrl.searchParams.set("_action", actionPath);
 

--- a/packages/rakkasjs/src/features/run-server-side/lib-common.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-common.ts
@@ -105,8 +105,7 @@ export function useFormAction(desc: [callSiteId: string, closure: any[]]) {
 	let closurePath = stringified.map(encodeFileNameSafe).join("/");
 	if (closurePath) closurePath = "/" + closurePath;
 
-	const actionPath =
-		import.meta.env.RAKKAS_BUILD_ID + "/" + callSiteId + closurePath;
+	const actionPath = callSiteId + closurePath;
 	const actionUrl = new URL(url);
 	actionUrl.searchParams.set("_action", actionPath);
 

--- a/packages/rakkasjs/src/features/run-server-side/lib-server.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-server.ts
@@ -30,7 +30,7 @@ function runSSQImpl(
 			let closurePath = stringified.map(encodeFileNameSafe).join("/");
 			if (closurePath) closurePath = "/" + closurePath;
 
-			const url = "/_data/" + callSiteId + closurePath + "/d.js";
+			const url = "/_app/data/" + callSiteId + closurePath + "/d.js";
 
 			await (ctx.platform as any).render(
 				url,
@@ -71,7 +71,7 @@ function useSSQImpl(
 					let closurePath = stringified.map(encodeFileNameSafe).join("/");
 					if (closurePath) closurePath = "/" + closurePath;
 
-					const url = "/_data/" + callSiteId + closurePath + "/d.js";
+					const url = "/_app/data/" + callSiteId + closurePath + "/d.js";
 
 					await (ctx!.platform as any).render(
 						url,

--- a/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
+++ b/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
@@ -17,10 +17,26 @@ const runServerSideServerHooks: ServerHooks = {
 			}
 
 			action = action || ctx.url.pathname.slice(prefix.length);
-			const [buildId, moduleId, counter, ...closure] = action.split("/");
-			if (buildId !== import.meta.env.RAKKAS_BUILD_ID) {
+			const [buildId = "", ...rest] = action.split("/");
+
+			let uniqueId: string;
+			let moduleId: string;
+			let counter: string;
+			let closure: string[];
+
+			const manifest = await import(
+				"virtual:rakkasjs:run-server-side:manifest"
+			);
+
+			if (buildId === "id") {
+				[uniqueId, ...closure] = rest;
+				const callSiteId = manifest.idMap[uniqueId] || "";
+				[moduleId = "", counter = ""] = callSiteId.split("/");
+			} else if (buildId !== import.meta.env.RAKKAS_BUILD_ID) {
 				// 410 Gone would be more appropriate but it won't work with statically rendered pages
 				return new Response("Outdated client", { status: 404 });
+			} else {
+				[moduleId = "", counter = "", ...closure] = rest;
 			}
 
 			let closureContents: unknown[];
@@ -56,11 +72,7 @@ const runServerSideServerHooks: ServerHooks = {
 				return new Response("Parse error", { status: 400 });
 			}
 
-			const manifest = await import(
-				"virtual:rakkasjs:run-server-side:manifest"
-			);
-
-			const importer = manifest.default[decodeURIComponent(moduleId)];
+			const importer = manifest.moduleMap[decodeURIComponent(moduleId)];
 			if (!importer) return;
 
 			const module = await importer();

--- a/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
+++ b/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
@@ -9,7 +9,7 @@ import { EventStreamContentType } from "@microsoft/fetch-event-source";
 const runServerSideServerHooks: ServerHooks = {
 	middleware: {
 		beforePages: async (ctx) => {
-			const prefix = `/_data/`;
+			const prefix = `/_app/data/`;
 			let action = ctx.url.searchParams.get("_action");
 
 			if (!ctx.url.pathname.startsWith(prefix) && !action) {
@@ -17,6 +17,7 @@ const runServerSideServerHooks: ServerHooks = {
 			}
 
 			action = action || ctx.url.pathname.slice(prefix.length);
+
 			const [buildId = "", ...rest] = action.split("/");
 
 			let uniqueId: string;

--- a/packages/rakkasjs/src/features/run-server-side/vite-plugin.ts
+++ b/packages/rakkasjs/src/features/run-server-side/vite-plugin.ts
@@ -39,7 +39,7 @@ export default function runServerSide(): PluginOption[] {
 			async load(id) {
 				if (id === "virtual:rakkasjs:run-server-side:manifest") {
 					if (resolvedConfig.command === "serve") {
-						return `export const  new Proxy({}, { get: (_, name) => () => import(/* @vite-ignore */ "/" + name) });`;
+						return `export const moduleMap = new Proxy({}, { get: (_, name) => () => import(/* @vite-ignore */ "/" + name) });`;
 					} else if (!moduleManifest) {
 						return `throw new Error("[virtual:rakkasjs:run-server-side:manifest]: Module manifest is not available on the client");`;
 					}

--- a/packages/rakkasjs/src/features/run-server-side/vite-plugin.ts
+++ b/packages/rakkasjs/src/features/run-server-side/vite-plugin.ts
@@ -5,10 +5,16 @@ import { babelTransformClientSideHooks } from "./implementation/transform/transf
 
 export default function runServerSide(): PluginOption[] {
 	let idCounter = 0;
-	const moduleIdMap: Record<string, string> = {};
+	const moduleIdMap: Record<string, string> = Object.create(null);
+	const uniqueIdMap: Record<string, string> = Object.create(null);
 
 	let resolvedConfig: ResolvedConfig;
-	let moduleManifest: any;
+	let moduleManifest:
+		| {
+				moduleIdMap: Record<string, string>;
+				uniqueIdMap: Record<string, string>;
+		  }
+		| undefined;
 
 	return [
 		{
@@ -33,20 +39,35 @@ export default function runServerSide(): PluginOption[] {
 			async load(id) {
 				if (id === "virtual:rakkasjs:run-server-side:manifest") {
 					if (resolvedConfig.command === "serve") {
-						return `export default new Proxy({}, { get: (_, name) => () => import(/* @vite-ignore */ "/" + name) });`;
+						return `export const  new Proxy({}, { get: (_, name) => () => import(/* @vite-ignore */ "/" + name) });`;
 					} else if (!moduleManifest) {
 						return `throw new Error("[virtual:rakkasjs:run-server-side:manifest]: Module manifest is not available on the client");`;
 					}
 
-					let code = "export default {";
+					let code = "export const moduleMap = {";
 
-					for (const [filePath, moduleId] of Object.entries(moduleManifest)) {
+					for (const [filePath, moduleId] of Object.entries(
+						moduleManifest.moduleIdMap,
+					)) {
 						code += `\n\t${JSON.stringify(
 							moduleId,
 						)}: () => import(${JSON.stringify("/" + filePath)}),`;
 					}
 
+					code += "\n};\n";
+
+					code += "export const idMap = {";
+
+					for (const [uniqueId, callSiteId] of Object.entries(
+						moduleManifest.uniqueIdMap,
+					)) {
+						code += `\n\t${JSON.stringify(uniqueId)}: ${JSON.stringify(
+							callSiteId,
+						)},`;
+					}
+
 					code += "\n};";
+
 					return code;
 				}
 			},
@@ -61,8 +82,14 @@ export default function runServerSide(): PluginOption[] {
 			},
 
 			async transform(code, id, options) {
+				const uniqueIds: Array<string | undefined> | undefined =
+					resolvedConfig.command === "build" && !options?.ssr ? [] : undefined;
 				const plugins: PluginItem[] = [];
-				const ref = { current: false };
+				const ref = {
+					moduleId: "",
+					modified: false,
+					uniqueIds,
+				};
 				let moduleId: string;
 
 				if (
@@ -76,18 +103,19 @@ export default function runServerSide(): PluginOption[] {
 					if (resolvedConfig.command === "serve") {
 						moduleId = id.slice(resolvedConfig.root.length + 1);
 					} else if (moduleManifest) {
-						moduleId = moduleManifest[id];
+						moduleId = moduleManifest.moduleIdMap[id];
 					} else {
 						moduleId = (idCounter++).toString(36);
 					}
 
-					// moduleId can be undefined if the file is not in the manifest
-					// e.g. if it hasn't been used. We can safely ignore it in that case.
+					moduleId = encodeURIComponent(moduleId);
+
 					if (moduleId) {
+						ref.moduleId = process.env.RAKKAS_BUILD_ID + "/" + moduleId;
 						plugins.push(
 							options?.ssr
-								? babelTransformServerSideHooks(moduleId)
-								: babelTransformClientSideHooks(moduleId, ref),
+								? babelTransformServerSideHooks(ref)
+								: babelTransformClientSideHooks(ref),
 						);
 					}
 				}
@@ -104,20 +132,33 @@ export default function runServerSide(): PluginOption[] {
 					sourceMaps:
 						resolvedConfig.command === "serve" ||
 						!!resolvedConfig.build.sourcemap,
+				}).catch((error) => {
+					this.error(error.message);
 				});
 
-				if (ref.current) {
-					moduleIdMap[id] = moduleId!;
+				if (!result) {
+					return null;
 				}
 
-				if (result) {
-					return {
-						code: result.code!,
-						map: result.map,
-					};
-				} else {
-					this.warn(`[rakkasjs:run-server-side]: Failed to transform ${id}`);
+				if (ref.modified) {
+					moduleIdMap[id] = moduleId!;
+
+					if (uniqueIds) {
+						for (const [i, uniqueId] of uniqueIds.entries()) {
+							if (uniqueId) {
+								if (uniqueIdMap[uniqueId]) {
+									this.error(`Duplicate unique ID ${uniqueId} in ${id}`);
+								}
+								uniqueIdMap[uniqueId] = moduleId! + "/" + i;
+							}
+						}
+					}
 				}
+
+				return {
+					code: result.code!,
+					map: result.map,
+				};
 			},
 
 			buildStepStart(_info, forwarded) {
@@ -125,7 +166,7 @@ export default function runServerSide(): PluginOption[] {
 			},
 
 			buildStepEnd() {
-				return moduleIdMap;
+				return { moduleIdMap, uniqueIdMap };
 			},
 		},
 	];

--- a/packages/rakkasjs/src/runtime/virtual-modules.d.ts
+++ b/packages/rakkasjs/src/runtime/virtual-modules.d.ts
@@ -74,7 +74,7 @@ declare module "virtual:rakkasjs:client-manifest" {
 }
 
 declare module "virtual:rakkasjs:run-server-side:manifest" {
-	const manifest: Record<
+	export const moduleMap: Record<
 		string,
 		() => Promise<{
 			$runServerSide$: Array<
@@ -86,7 +86,8 @@ declare module "virtual:rakkasjs:run-server-side:manifest" {
 			>;
 		}>
 	>;
-	export default manifest;
+
+	export const idMap: Record<string, string>;
 }
 
 declare module "virtual:rakkasjs:hattip-entry" {

--- a/packages/rakkasjs/src/vite-plugin/inject-config.ts
+++ b/packages/rakkasjs/src/vite-plugin/inject-config.ts
@@ -69,6 +69,10 @@ export function injectConfig(options: InjectConfigOptions): Plugin {
 			return {
 				buildSteps,
 
+				build: {
+					assetsDir: "_app/assets",
+				},
+
 				ssr: {
 					external: ["react-dom/server.browser"],
 					noExternal: ["rakkasjs", "@vavite/expose-vite-dev-server"],

--- a/packages/rakkasjs/src/vite-plugin/resolve-client-manifest.ts
+++ b/packages/rakkasjs/src/vite-plugin/resolve-client-manifest.ts
@@ -45,12 +45,8 @@ export function resolveClientManifest(): Plugin {
 			resolvedConfig = config;
 		},
 
-		async buildEnd(error) {
-			if (
-				error ||
-				resolvedConfig.command === "serve" ||
-				resolvedConfig.build.ssr
-			) {
+		async closeBundle() {
+			if (resolvedConfig.command === "serve" || resolvedConfig.build.ssr) {
 				return;
 			}
 

--- a/packages/rakkasjs/src/vite-plugin/resolve-client-manifest.ts
+++ b/packages/rakkasjs/src/vite-plugin/resolve-client-manifest.ts
@@ -45,8 +45,12 @@ export function resolveClientManifest(): Plugin {
 			resolvedConfig = config;
 		},
 
-		async closeBundle() {
-			if (resolvedConfig.command === "serve" || resolvedConfig.build.ssr) {
+		async buildEnd(error) {
+			if (
+				error ||
+				resolvedConfig.command === "serve" ||
+				resolvedConfig.build.ssr
+			) {
 				return;
 			}
 

--- a/testbed/kitchen-sink/src/routes/run-ssq/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/run-ssq/index.page.tsx
@@ -5,10 +5,14 @@ export default function UseSsq() {
 	const b = 5;
 
 	const fetched = useQuery("run-ssq", (ctx) => {
-		return runServerSideQuery(ctx.requestContext, () => ({
-			result: a + b,
-			ssr: import.meta.env.SSR,
-		}));
+		return runServerSideQuery(
+			ctx.requestContext,
+			() => ({
+				result: a + b,
+				ssr: import.meta.env.SSR,
+			}),
+			{ uniqueId: "customId" },
+		);
 	});
 
 	return (


### PR DESCRIPTION
This PR enables stable deploys with the `uniqueId` option in `*ServerSide*` family of functions.

Normally Rakkas uses versioned URLs for its data routes. For example, each call site for `useServerSideQuery` will generate a URL in the form of `_app/data/{BUILD_ID}/...`. This allows Rakkas to detect stale deploys and perform a full reload. But this isn't always ideal.

One way to deal with it is to keep running the old server along side the new one and use a reverse proxy or CDN in front of it to route requests to the appropriate server. But it requires quite a bit of wiring.

With this PR, it is now possible to give each call site a stable unique ID that stays identical from deploy to deploy. E.g. a `useServerSideQuery(() => { ... }, { uniqueId: "foo" })` will always map to the URL `/_app/data/id/foo` without versioning. In this case, it is the user's responsibility to take care of versioning when necessary.

The `uniqueId` option must be a string literal and it has to be unique across the application. When using static prerendering on Windows, it must be unique in a case insensitive way but this is not enforced yet.

This PR also adds partial support for Vite's `base` config option. `base` can now be set to a different domain (e.g. `"https://cdn.example.com/"`) but the pathname component of the URL still has to be `/`. This allows serving static assets from a separate domain. The static server has to set CORS headers if necessary, nonces are not yet supported.