### PR TITLE
chore: improve react-query example

### DIFF
--- a/examples/react-query/src/entry-hattip.tsx
+++ b/examples/react-query/src/entry-hattip.tsx
@@ -17,17 +17,15 @@ export default createRequestHandler({
 		let thereIsUnsentData = false;
 		let unsentData: Record<string, unknown> = Object.create(null);
 
-		const queryCache = new QueryCache({
-			onSuccess(data, query) {
-				unsentData[query.queryHash] = data;
-				thereIsUnsentData = true;
-			},
+		const queryClient = new QueryClient();
+		queryClient.getQueryCache().subscribe(({ type, query }) => {
+			if (type !== "updated" || query.state.status !== "success") return;
+			unsentData[query.queryHash] = query.state.data;
+			thereIsUnsentData = true;
 		});
 
-		const queryClient = new QueryClient({ queryCache });
-
 		return {
-			extendPageContext(ctx) {
+			async extendPageContext(ctx) {
 				ctx.reactQueryClient = queryClient;
 			},
 


### PR DESCRIPTION
This PR improves the react-query integration example by switching to using `queryCache().subscribe` to track cache changes from `onSuccess`.