### PR TITLE
fix: prevent clicking native hash anchors from crashing

### DIFF
--- a/packages/rakkasjs/src/features/client-side-navigation/implementation.tsx
+++ b/packages/rakkasjs/src/features/client-side-navigation/implementation.tsx
@@ -249,6 +249,20 @@ export function initialize() {
 	lastLocation = [location.href, serialId];
 
 	addEventListener("popstate", handleNavigation);
+	addEventListener("hashchange", () => {
+		const id = createUniqueId();
+		const index = nextIndex++;
+
+		history.replaceState(
+			{
+				id,
+				index,
+				scroll: true,
+			},
+			"",
+			location.href,
+		);
+	});
 }
 
 function handleNavigation(e: unknown) {

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1041,6 +1041,17 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 			const text = await r.text();
 			expect(text).toContain("Flat Route");
 		});
+
+		test("hash anchors don't crash", async () => {
+			await page.goto(host + "/hash-anchor");
+			await page.waitForSelector(".hydrated");
+
+			await page.click("a");
+
+			await page.waitForFunction(
+				() => document.documentElement.scrollTop !== 0,
+			);
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/src/routes/hash-anchor/_hash-anchor.page.tsx
+++ b/testbed/kitchen-sink/src/routes/hash-anchor/_hash-anchor.page.tsx
@@ -1,0 +1,11 @@
+export default function HashAnchorPage() {
+	return (
+		<div>
+			<h1>Hash Anchor Test Page</h1>
+			<div style={{ height: "200vh" }}>
+				<a href="#hash-anchor">Hash Anchor</a>
+			</div>
+			<h2 id="hash-anchor">Hash Anchor</h2>
+		</div>
+	);
+}


### PR DESCRIPTION
Fixes #155 