### PR TITLE
types: make useRouteParams generic

### DIFF
--- a/packages/rakkasjs/src/features/pages/lib.ts
+++ b/packages/rakkasjs/src/features/pages/lib.ts
@@ -6,6 +6,6 @@ export { DefaultErrorPage } from "./DefaultErrorPage";
 /**
  * Hook for getting the route parameters.
  */
-export function useRouteParams(): Record<string, string> {
+export function useRouteParams<T extends Record<string, string>>(): T {
 	return useContext(RouteParamsContext);
 }

--- a/packages/rakkasjs/src/features/pages/lib.ts
+++ b/packages/rakkasjs/src/features/pages/lib.ts
@@ -7,5 +7,5 @@ export { DefaultErrorPage } from "./DefaultErrorPage";
  * Hook for getting the route parameters.
  */
 export function useRouteParams<T extends Record<string, string>>(): T {
-	return useContext(RouteParamsContext);
+	return useContext(RouteParamsContext) as T;
 }


### PR DESCRIPTION
I'm currently manually defining a `Params` type and would love to be able to pass that into `useRouteParams`.

What do you think? not exactly sure I think `extend` would be the right here?
Alternative could be `<T = Record<string, string>>(): T`