### PR TITLE
fix: useId mismatch

### DIFF
--- a/packages/rakkasjs/src/features/pages/middleware.tsx
+++ b/packages/rakkasjs/src/features/pages/middleware.tsx
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import React, { Fragment, ReactNode, StrictMode, Suspense } from "react";
+import React, { StrictMode, Suspense } from "react";
 import {
 	renderToReadableStream,
 	renderToStaticMarkup,
@@ -10,7 +10,6 @@ import { App, RouteContext } from "../../runtime/App";
 import { isBot } from "../../runtime/isbot";
 import { findPage, RouteMatch } from "../../internal/find-page";
 import {
-	Redirect,
 	ResponseContext,
 	ResponseContextProps,
 } from "../response-manipulation/implementation";
@@ -30,7 +29,7 @@ import {
 	PrerenderResult,
 	ServerSidePageContext,
 } from "../../runtime/page-types";
-import { Head, LookupHookResult } from "../../lib";
+import { LookupHookResult } from "../../lib";
 import { uneval } from "devalue";
 import viteDevServer from "@vavite/expose-vite-dev-server/vite-dev-server";
 import { PageRequestHooks } from "../../runtime/hattip-handler";
@@ -346,19 +345,6 @@ export default async function renderPageRoute(
 		typeof p?.meta === "function" ? p.meta(meta) : Object.assign(meta, p?.meta),
 	);
 
-	const preloadNode: ReactNode[] = preloaded
-		.map((result, i) => {
-			return (
-				(result?.head || result?.redirect) && (
-					<Fragment key={i}>
-						{<Head {...result?.head} />}
-						{result?.redirect && <Redirect {...result?.redirect} />}
-					</Fragment>
-				)
-			);
-		})
-		.filter(Boolean);
-
 	let app = (
 		<App
 			beforePageLookupHandlers={beforePageLookupHandlers}
@@ -368,15 +354,6 @@ export default async function renderPageRoute(
 			ssrModules={modules}
 		/>
 	);
-
-	if (preloadNode.length) {
-		app = (
-			<>
-				{preloadNode}
-				{app}
-			</>
-		);
-	}
 
 	if (commonHooks.wrapApp) {
 		app = commonHooks.wrapApp(app);

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -355,6 +355,18 @@ export async function loadRoute(
 
 	if (import.meta.env.SSR) {
 		meta = ssrMeta;
+		preloadNode = ssrPreloaded!
+			.map((result, i) => {
+				return (
+					(result?.head || result?.redirect) && (
+						<Fragment key={i}>
+							{<Head {...result?.head} />}
+							{result?.redirect && <Redirect {...result?.redirect} />}
+						</Fragment>
+					)
+				);
+			})
+			.filter(Boolean);
 	} else {
 		const preloaded = layoutStack.map((r) => r[1]).reverse();
 

--- a/testbed/kitchen-sink/src/routes/layout.tsx
+++ b/testbed/kitchen-sink/src/routes/layout.tsx
@@ -22,4 +22,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
 	);
 }
 
-MainLayout.preload = (): PreloadResult => ({ meta: { key: 1 } });
+MainLayout.preload = (): PreloadResult => ({
+	meta: { key: 1 },
+	head: {},
+});


### PR DESCRIPTION
The new `useRouteParams` hook's handling broke `useId` in some cases. This PR fixes it.