### PR TITLE
feat: allow setting html, head, and body attributes via Head

### DIFF
--- a/packages/rakkasjs/src/features/head/implementation.ts
+++ b/packages/rakkasjs/src/features/head/implementation.ts
@@ -11,6 +11,9 @@ export const defaultHeadTags: HeadProps = {
 	charset: "utf-8",
 	viewport: "width=device-width, initial-scale=1",
 	title: "Rakkas App",
+	htmlAttributes: {},
+	headAttributes: {},
+	bodyAttributes: {},
 };
 
 export const clientHeadTags: HeadProps = { ...defaultHeadTags };
@@ -33,6 +36,17 @@ export function scheduleHeadUpdate() {
 			const updated = new Set<HTMLElement>();
 
 			for (const [name, attributes] of Object.entries(clientHeadTags)) {
+				if (name === "htmlAttributes") {
+					handleAttributes(document.documentElement, attributes);
+					continue;
+				} else if (name === "headAttributes") {
+					handleAttributes(document.head, attributes);
+					continue;
+				} else if (name === "bodyAttributes") {
+					handleAttributes(document.body, attributes);
+					continue;
+				}
+
 				delete clientHeadTags[name];
 
 				let el: HTMLElement | null | undefined;
@@ -135,4 +149,23 @@ export function scheduleHeadUpdate() {
 
 function select(selector: string) {
 	return document.head.querySelector(selector) as HTMLElement | null;
+}
+
+function handleAttributes(
+	el: HTMLElement,
+	attributes: Record<string, string> | null | string,
+) {
+	if (!attributes || typeof attributes === "string") {
+		throw new Error(`Invalid attributes for ${el.tagName}: ${attributes}`);
+	}
+
+	for (const attr of el.attributes) {
+		if (!(attr.name in attributes)) {
+			el.removeAttribute(attr.name);
+		}
+	}
+
+	for (const [attr, value] of Object.entries(attributes)) {
+		el.setAttribute(attr, value);
+	}
 }

--- a/packages/rakkasjs/src/features/head/server-hooks.tsx
+++ b/packages/rakkasjs/src/features/head/server-hooks.tsx
@@ -13,7 +13,7 @@ const headServerHooks: ServerHooks = {
 				return <HeadContext.Provider value={tags}>{app}</HeadContext.Provider>;
 			},
 
-			emitToDocumentHead() {
+			emitToDocumentHead(speciallAttributes) {
 				let result = "";
 
 				const sorted = Object.entries(tags).sort(
@@ -42,6 +42,18 @@ const headServerHooks: ServerHooks = {
 								attributes,
 							)}">`;
 						}
+					} else if (
+						["htmlAttributes", "headAttributes", "bodyAttributes"].includes(
+							name,
+						)
+					) {
+						if (!attributes || typeof attributes === "string") {
+							throw new Error(`Invalid ${name} attribute`);
+						}
+						Object.assign(
+							speciallAttributes[name as keyof typeof speciallAttributes],
+							attributes,
+						);
 					} else {
 						result += "<" + tag;
 						for (const [attr, value] of Object.entries(attributes)) {

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -51,7 +51,11 @@ export interface PageRequestHooks {
 	 */
 	wrapApp?(app: ReactElement): ReactElement;
 	/** Write to the document's head section */
-	emitToDocumentHead?(): ReactElement | string | undefined;
+	emitToDocumentHead?(specialAttributes: {
+		htmlAttributes: Record<string, string>;
+		headAttributes: Record<string, string>;
+		bodyAttributes: Record<string, string>;
+	}): ReactElement | string | undefined;
 	/** Emit a chunk of HTML before each time React emits a chunk */
 	emitBeforeSsrChunk?(): string | undefined;
 	/** Wrap React's SSR stream */

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1015,13 +1015,25 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 		});
 
 		test("sets head tags", async () => {
-			const r = await fetch(host + "/head");
-			const text = await r.text();
-			expect(text).toContain(
-				'<meta charset="utf-8">' +
-					'<meta name="viewport" content="width=device-width, initial-scale=1">' +
-					"<title>The head page</title>" +
-					'<link rel="canonical" href="http://localhost:3000/head" data-rh="canonical">',
+			await page.goto(host + "/head");
+			await page.waitForSelector(".hydrated");
+
+			await page.waitForFunction(
+				() => document.querySelector("link[rel=canonical]") !== null,
+			);
+
+			await page.waitForFunction(() => document.documentElement.lang === "en");
+			await page.waitForFunction(
+				() => document.documentElement.className === "head-page",
+			);
+
+			await page.waitForSelector(".hydrated");
+
+			await page.click("a");
+
+			await page.waitForFunction(() => document.documentElement.lang === "en");
+			await page.waitForFunction(
+				() => document.documentElement.className === "",
 			);
 		});
 

--- a/testbed/kitchen-sink/src/routes/head/_head.page.tsx
+++ b/testbed/kitchen-sink/src/routes/head/_head.page.tsx
@@ -1,6 +1,11 @@
-import type { Page } from "rakkasjs";
+import { Link, type Page } from "rakkasjs";
 
-const HeadPage: Page = () => <p>Check my head tags!</p>;
+const HeadPage: Page = () => (
+	<div>
+		<p>Check my head tags!</p>
+		<Link href="/head/elsewhere">Go elsewhere</Link>
+	</div>
+);
 
 export default HeadPage;
 
@@ -11,6 +16,9 @@ HeadPage.preload = () => ({
 			tagName: "link",
 			rel: "canonical",
 			href: "http://localhost:3000/head",
+		},
+		htmlAttributes: {
+			class: "head-page",
 		},
 	},
 });

--- a/testbed/kitchen-sink/src/routes/head/elsewhere.page.tsx
+++ b/testbed/kitchen-sink/src/routes/head/elsewhere.page.tsx
@@ -1,0 +1,10 @@
+import { Link, type Page } from "rakkasjs";
+
+const HeadPage2: Page = () => (
+	<div>
+		<p>Check my head tags!</p>
+		<Link href="/head">Go to head test</Link>
+	</div>
+);
+
+export default HeadPage2;

--- a/testbed/kitchen-sink/src/routes/layout.tsx
+++ b/testbed/kitchen-sink/src/routes/layout.tsx
@@ -3,7 +3,7 @@ import { PreloadResult, useLocation } from "rakkasjs";
 
 export default function MainLayout({ children }: { children: ReactNode }) {
 	useEffect(() => {
-		document.body.classList.add("hydrated");
+		document.getElementById("root")!.classList.add("hydrated");
 	});
 
 	const { pending } = useLocation();
@@ -24,5 +24,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
 
 MainLayout.preload = (): PreloadResult => ({
 	meta: { key: 1 },
-	head: {},
+	head: {
+		htmlAttributes: { lang: "en" },
+	},
 });

--- a/testbed/static/src/routes/layout.tsx
+++ b/testbed/static/src/routes/layout.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 export default function MainLayout({ children }: LayoutProps) {
 	useEffect(() => {
-		document.body.classList.add("hydrated");
+		document.getElementById("root")!.classList.add("hydrated");
 	});
 
 	return (


### PR DESCRIPTION
This PR allows setting the attributes for `<html>`, `<head>`, and `<body>` elements via the `htmlAttributes`, `headAttributes`, and `bodyAttributes` properties of the `Head` component or the `head` property of the return value of a preload function.

Example:

```ts
MainLayout.preload = (): PreloadResult => ({
	head: {
		htmlAttributes: { lang: "en" },
	},
});
```