### PR TITLE
feat: implement getRequestContext

### DIFF
--- a/packages/rakkasjs/src/features/async-local-request-context/implementation.ts
+++ b/packages/rakkasjs/src/features/async-local-request-context/implementation.ts
@@ -1,0 +1,6 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { RequestContext } from "@hattip/compose";
+
+export const requestContextStorage = AsyncLocalStorage
+	? new AsyncLocalStorage<RequestContext>()
+	: undefined;

--- a/packages/rakkasjs/src/features/async-local-request-context/lib-client.ts
+++ b/packages/rakkasjs/src/features/async-local-request-context/lib-client.ts
@@ -1,0 +1,5 @@
+import type { RequestContext } from "@hattip/compose";
+
+export function getRequestContext(): RequestContext | undefined {
+	return undefined;
+}

--- a/packages/rakkasjs/src/features/async-local-request-context/lib-server.ts
+++ b/packages/rakkasjs/src/features/async-local-request-context/lib-server.ts
@@ -1,0 +1,21 @@
+import type { RequestContext } from "@hattip/compose";
+import { requestContextStorage } from "./implementation";
+
+/**
+ * Get the request context for the current request.
+ *
+ * On the server, it will return the context for the current request. On the
+ * client, it will return `undefined`.
+ *
+ * This feature depends on AsyncLocalStorage support. If it is not available,
+ * it will throw an error.
+ */
+export function getRequestContext(): RequestContext | undefined {
+	const ctx = requestContextStorage?.getStore();
+
+	if (!ctx) {
+		throw new Error("Request context not found");
+	}
+
+	return ctx;
+}

--- a/packages/rakkasjs/src/features/async-local-request-context/server-hooks.ts
+++ b/packages/rakkasjs/src/features/async-local-request-context/server-hooks.ts
@@ -1,0 +1,10 @@
+import { ServerHooks } from "../../lib";
+import { requestContextStorage } from "./implementation";
+
+const asyncLocalRequestContextServerHooks: ServerHooks = {
+	middleware: {
+		beforeAll: [(ctx) => requestContextStorage?.run(ctx, ctx.next)],
+	},
+};
+
+export default asyncLocalRequestContextServerHooks;

--- a/packages/rakkasjs/src/lib/client.ts
+++ b/packages/rakkasjs/src/lib/client.ts
@@ -17,3 +17,5 @@ export {
 export { startClient } from "../runtime/client-entry";
 
 export * from "../features/pages/lib";
+
+export { getRequestContext } from "../features/async-local-request-context/lib-client";

--- a/packages/rakkasjs/src/lib/index.ts
+++ b/packages/rakkasjs/src/lib/index.ts
@@ -60,3 +60,5 @@ export type {
 	ServerHooks,
 	PageRequestHooks as PageHooks,
 } from "../runtime/hattip-handler";
+
+export type { getRequestContext } from "../features/async-local-request-context/lib-server";

--- a/packages/rakkasjs/src/lib/server.ts
+++ b/packages/rakkasjs/src/lib/server.ts
@@ -17,3 +17,5 @@ export {
 export { createRequestHandler } from "../runtime/hattip-handler";
 
 export * from "../features/pages/lib";
+
+export { getRequestContext } from "../features/async-local-request-context/lib-server";

--- a/packages/rakkasjs/src/runtime/feature-server-hooks.tsx
+++ b/packages/rakkasjs/src/runtime/feature-server-hooks.tsx
@@ -1,3 +1,4 @@
+import asyncLocalRequestContextServerHooks from "../features/async-local-request-context/server-hooks";
 import headHooks from "../features/head/server-hooks";
 import useQueryHooks from "../features/use-query/server-hooks";
 import useServerSideHooks from "../features/run-server-side/server-hooks";
@@ -6,6 +7,7 @@ import clientSideNavigationHooks from "../features/client-side-navigation/server
 import { ServerHooks } from "./hattip-handler";
 
 const serverHooks: ServerHooks[] = [
+	asyncLocalRequestContextServerHooks,
 	headHooks,
 	useQueryHooks,
 	useServerSideHooks,

--- a/packages/rakkasjs/tsup.config.ts
+++ b/packages/rakkasjs/tsup.config.ts
@@ -89,6 +89,7 @@ export default defineConfig([
 		platform: "node",
 		shims: false,
 		external: [
+			"node:async_hooks",
 			"virtual:rakkasjs:hattip-entry",
 			"virtual:rakkasjs:common-hooks",
 			"virtual:rakkasjs:api-routes",

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1053,6 +1053,21 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 				() => document.documentElement.scrollTop !== 0,
 			);
 		});
+
+		test("getRequestContext works", async () => {
+			await page.goto(host + "/alsrc");
+			await page.waitForFunction(() =>
+				document.body?.innerText.includes("Success"),
+			);
+
+			await page.goto(host + "/alsrc/elsewhere");
+			await page.waitForSelector(".hydrated");
+			await page.click("a");
+
+			await page.waitForFunction(() =>
+				document.body?.innerText.includes("Success"),
+			);
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/package.json
+++ b/testbed/kitchen-sink/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "rakkas --port 3000",
     "build": "rakkas build",
-    "build:cfw": "cross-env RAKKAS_TARGET=cloudflare-workers rakkas build",
+    "build:cfw": "cross-env RAKKAS_TARGET=cloudflare-workers-node-compat rakkas build",
     "build:netlify": "rimraf .netlify/edge-functions-dist && cross-env RAKKAS_TARGET=netlify rakkas build",
     "build:netlify-edge": "cross-env RAKKAS_TARGET=netlify-edge rakkas build",
     "build:deno": "cross-env RAKKAS_TARGET=deno rakkas build",

--- a/testbed/kitchen-sink/src/routes/alsrc/elsewhere.page.tsx
+++ b/testbed/kitchen-sink/src/routes/alsrc/elsewhere.page.tsx
@@ -1,0 +1,5 @@
+import { Link } from "rakkasjs";
+
+export default function AlsRcElsewhere() {
+	return <Link href="/alsrc">Async Local Request Context</Link>;
+}

--- a/testbed/kitchen-sink/src/routes/alsrc/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/alsrc/index.page.tsx
@@ -1,0 +1,17 @@
+import { useQuery, runServerSideQuery, getRequestContext } from "rakkasjs";
+
+export default function AlsRc() {
+	const { data } = useQuery("alsrc", () => {
+		try {
+			const ctx = getRequestContext();
+			return runServerSideQuery(ctx, () => {
+				return "Success!";
+			});
+		} catch (error) {
+			console.error(error);
+			return "getRequestContext() failed";
+		}
+	});
+
+	return <p>{data}</p>;
+}

--- a/testbed/kitchen-sink/src/routes/run-ssq/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/run-ssq/index.page.tsx
@@ -4,7 +4,7 @@ export default function UseSsq() {
 	const a = 2;
 	const b = 5;
 
-	const fetched1 = useQuery("run-ssq", (ctx) => {
+	const fetched1 = useQuery("run-ssq-1", (ctx) => {
 		return runServerSideQuery(
 			ctx.requestContext,
 			() => ({
@@ -15,7 +15,7 @@ export default function UseSsq() {
 		);
 	});
 
-	const fetched2 = useQuery("run-ssq", (ctx) => {
+	const fetched2 = useQuery("run-ssq-2", (ctx) => {
 		return runServerSideQuery(
 			ctx.requestContext,
 			() => ({

--- a/testbed/kitchen-sink/wrangler.toml
+++ b/testbed/kitchen-sink/wrangler.toml
@@ -1,8 +1,6 @@
 
-compatibility_date = "2021-11-01"
-compatibility_flags = [
-  "streams_enable_constructors",
-]
+compatibility_date = "2023-12-18"
+compatibility_flags = ["nodejs_compat"]
 main = "dist/server/cloudflare-workers-bundle.js"
 name = "rakkas-testbed"
 usage_model = 'bundled'


### PR DESCRIPTION
This PR implements a new API named `getRequestContext`.

On the server, it will return the context for the current request. On the client, it will return `undefined`.

## Use case

`runServerSideQuery` expects the request context as its first argument. Before this feature, the request context could only be obtained via the `useRequestContext` hook or the arguments passed to the `preload` function. This complicates the implementation of `createQueryOptions`-type APIs.

Having to pass the context argument around your server codebase everywhere it is needed also unnecessarily complicates things. This API makes it easily accessible without having to pass it around.

## Availability

This feature depends on `AsyncLocalStorage` support. If it is not available, it will throw an error. Most deployment targets do support it. But there are exceptions:

On **Cloudflare Workers**, `AsyncLocalStorage` requires adding `compatibility_flags = ["nodejs_compat"]` to `wrangler.toml` and using the new `"cloudflare-workers-node-compat"` adapter instead of plain `"cloudflare-workers"`.

**Lagon** claims to have support but it doesn't seem to be working. The project is abandoned in any case.

**Fastly Compute@Edge** doesn't support it but Rakkas has no official support for it yet anyway.