### PR TITLE
feat!: createQuery function

### DIFF
--- a/examples/guide-samples/src/routes/preload/index.page.tsx
+++ b/examples/guide-samples/src/routes/preload/index.page.tsx
@@ -1,11 +1,7 @@
-import { Page, useQuery } from "rakkasjs";
+import { Page, createQuery, useQuery } from "rakkasjs";
 
 const PreloadPage: Page = () => {
-	const preloaded = useQuery("preload", () => {
-		// This will only run when refetching since it will be preloaded in the
-		// cache on first render.
-		return getFakeData();
-	});
+	const preloaded = useQuery(fakeDataQuery());
 
 	return (
 		<div>
@@ -21,9 +17,7 @@ export default PreloadPage;
 PreloadPage.preload = (ctx) => {
 	// Prefetch a query to avoid waterfalls caused by late discovery of data
 	// dependencies.
-	if (!ctx.queryClient.getQueryData("preload")) {
-		ctx.queryClient.prefetchQuery("preload", getFakeData());
-	}
+	ctx.queryClient.prefetchQuery(fakeDataQuery());
 
 	return {
 		// Set head meta tags. Unlike a Head component rendered in a page,
@@ -33,6 +27,10 @@ PreloadPage.preload = (ctx) => {
 	};
 };
 
-async function getFakeData() {
-	return "some fake data";
-}
+const fakeDataQuery = createQuery({
+	createKey: () => "preload",
+	queryFn() {
+		return "some fake data";
+	},
+	refetchInterval: 1000,
+});

--- a/examples/todo/src/routes/todo/index.page.tsx
+++ b/examples/todo/src/routes/todo/index.page.tsx
@@ -3,20 +3,17 @@ import { Todo } from "./Todo";
 import css from "./page.module.css";
 import {
 	Page,
+	createQuery,
 	runServerSideQuery,
+	useQuery,
 	useQueryClient,
 	useServerSideMutation,
-	useServerSideQuery,
 } from "rakkasjs";
 
 import { createTodo, readAllTodos } from "src/crud";
 
 const TodoPage: Page = () => {
-	const { data } = useServerSideQuery(readAllTodos, {
-		key: "todos",
-		refetchOnWindowFocus: true,
-		refetchOnReconnect: true,
-	});
+	const { data } = useQuery(todos());
 
 	const [text, setText] = useState("");
 
@@ -68,10 +65,14 @@ const TodoPage: Page = () => {
 export default TodoPage;
 
 TodoPage.preload = (ctx) => {
-	if (!ctx.queryClient.getQueryData("todos")) {
-		ctx.queryClient.prefetchQuery(
-			"todos",
-			runServerSideQuery(ctx.requestContext, readAllTodos),
-		);
-	}
+	ctx.queryClient.prefetchQuery(todos());
 };
+
+const todos = createQuery({
+	createKey: () => "todos",
+	queryFn(ctx) {
+		return runServerSideQuery(ctx.requestContext, readAllTodos);
+	},
+	refetchOnWindowFocus: true,
+	refetchOnReconnect: true,
+});

--- a/packages/rakkasjs/src/features/use-query/client-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/client-hooks.tsx
@@ -10,7 +10,7 @@ import {
 
 export default defineClientHooks({
 	extendPageContext(ctx) {
-		ctx.queryClient = createQueryClient(cache);
+		ctx.queryClient = createQueryClient(cache, ctx);
 	},
 
 	wrapApp(app) {

--- a/packages/rakkasjs/src/features/use-query/lib.ts
+++ b/packages/rakkasjs/src/features/use-query/lib.ts
@@ -4,5 +4,11 @@ export type {
 	QueryFn,
 	PageContext,
 	QueryClient,
+	CreateQueryOptions,
 } from "./implementation";
-export { useQuery, useQueryClient, usePageContext } from "./implementation";
+export {
+	useQuery,
+	useQueryClient,
+	usePageContext,
+	createQuery,
+} from "./implementation";

--- a/packages/rakkasjs/src/features/use-query/server-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/server-hooks.tsx
@@ -47,7 +47,7 @@ const useQueryServerHooks: ServerHooks = {
 				return result as any;
 			},
 
-			set(key: string, valueOrPromise: Promise<any>) {
+			set(key: string, valueOrPromise: any) {
 				this._items[key] = valueOrPromise;
 				if (valueOrPromise instanceof Promise) {
 					valueOrPromise.then(
@@ -89,7 +89,7 @@ const useQueryServerHooks: ServerHooks = {
 			},
 
 			extendPageContext(ctx) {
-				ctx.queryClient = createQueryClient(cache);
+				ctx.queryClient = createQueryClient(cache, ctx);
 			},
 
 			emitToDocumentHead() {

--- a/testbed/kitchen-sink/src/routes/create-query/elsewhere.page.tsx
+++ b/testbed/kitchen-sink/src/routes/create-query/elsewhere.page.tsx
@@ -1,0 +1,5 @@
+import { Link } from "rakkasjs";
+
+export default function CreateQueryElsewhere() {
+	return <Link href="/create-query">Create Query Page</Link>;
+}

--- a/testbed/kitchen-sink/src/routes/create-query/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/create-query/index.page.tsx
@@ -1,0 +1,31 @@
+import { Page, createQuery, runServerSideQuery, useQuery } from "rakkasjs";
+
+const CreateQueryPage: Page = () => {
+	const { data: double2 } = useQuery(doubler(2));
+	const { data: double5 } = useQuery(doubler(5));
+
+	return (
+		<div>
+			<p>2 * 2 = {double2}</p>
+			<p>2 * 5 = {double5}</p>
+		</div>
+	);
+};
+
+export default CreateQueryPage;
+
+CreateQueryPage.preload = (ctx) => {
+	const { prefetchQuery } = ctx.queryClient;
+	prefetchQuery(doubler(2));
+	prefetchQuery(doubler(5));
+};
+
+const doubler = createQuery({
+	createKey: (a: number) => `doubler:${a}`,
+	queryFn(ctx, a) {
+		return runServerSideQuery(ctx.requestContext, () => {
+			return a * 2;
+		});
+	},
+	staleTime: 1000,
+});

--- a/website/src/routes/_site/guide/preload-function.page.mdx
+++ b/website/src/routes/_site/guide/preload-function.page.mdx
@@ -16,6 +16,8 @@ You may think that the `preload` function is similar to `getServerSideProps` or 
 
 Consider a scenario where both a page and its parent layout need to fetch some data. Since the page is a child of the layout, its data fetching hook will not be rendered until the parent layout is rendered. If the data fetched by the page is not dependent on the data fetched by the layout, there is no reason to wait until the parent finishes. In this case, you can use the page's `preload` function like in the above example to start fetching immediately. This works because `preload` functions of the page and all its parent layouts are called in parallel.
 
+For this purpose, you can use the `ctx.queryClient.prefetchQuery` function in your `preload` function. To avoid repeating the same code in multiple places, you can use the `createQuery` API that returns a function that can build query options suitable to be passed to `prefetchQuery` and `useQuery`. There us no separate ~~`createServerSideQuery`~~ API, you can use `runServerSideQuery` in your query function to run code on the server.
+
 ## Head tags
 
 When using streaming SSR, `Head` components may be discovered _after_ the document head has been sent. To avoid SEO problems, Rakkas will hold the stream until the page is fully rendered when it detects that the [request is coming from a bot](dynamic-rendering). But in some cases, you may want the correct status, headers, and head tags to be sent even to browsers. `preload` offers a way to do this like in the above example.


### PR DESCRIPTION
This PR implements a new `createQuery` API.

**This is a breaking change** because it also changes how `queryClient.prefetchQuery` works (now it works much more like in TanStack Query).

## Problem

Suppose you can `fetchArticle(id)` function that fetches an article from somewhere. Normally you would use it with `useQuery` like this:

```ts
const id = props.params.id;
useQuery(`article/${id}`, () => fetchArticle(id), {
  cacheTime: 60_000,
  staleTime: 1000,
  refetchInterval: 1000,
  refetchOnReconnect: true,
  refetchOnWindowFocus: true,
});
```

The first problem is, you would have to repeat all the query options (like `cacheTime`, `refetchInterval` etc.) in every component you'd use `fetchArticle`.

The second problem is, you'd probably want to prefetch the query in a page's `preload` function to avoid waterfalls. It again requires error-prone code repetition:

```ts
ArticlePage.preload = (ctx) => {
  id = ctx.params.id;
  ctx.queryClient.prefetchQuery({
    queryKey: `article/${id}`,
    queryFn: () => fetchArticle(id),
    cacheTime: 60_000,
    staleTime: 1000,
  };
};
```

## Solution

`createQuery` returns a function that build query options suitable for passing to `useQuery` and `prefetchQuery`. In other words, it creates a reusable query family:

```ts
const articleQuery = createQuery({
  queryKey: (id: string) => `article/${id}`,
  queryFn: (ctx, id) => {
    // You could do something with the ctx parameter here
    return fetchArticle(id)
  },
  cacheTime: 60_000,
  staleTime: 1000,
  refetchInterval: 1000,
  refetchOnReconnect: true,
  refetchOnWindowFocus: true,
));

// ...
// In preload:
ArticlePage.preload = (ctx) => {
  id = ctx.params.id;
  ctx.queryClient.prefetchQuery(articleQuery(id));
};

// ...
// In render:
const id = props.params.id;
useQuery(articleQuery(id));
```

## `runServerSideQuery`

There is no separate ~~`createServerSideQuery`~~ API. You can use `runServerSideQuery` to run a query on the server side:

```ts
const articleQuery = createQuery({
  queryKey: (id: string) => `article/${id}`,
  queryFn: (ctx, id) => {
    return runServerSideQuery(ctx.requestContext, () => {
      return database.getArticle(id);
    });
  },
  cacheTime: 60_000,
  staleTime: 1000,
  refetchInterval: 1000,
  refetchOnReconnect: true,
  refetchOnWindowFocus: true,
));
```
