### PR TITLE
feat: server-only and client-only files

### DIFF
--- a/packages/rakkasjs/package.json
+++ b/packages/rakkasjs/package.json
@@ -97,6 +97,7 @@
     "cac": "^6.7.14",
     "cheerio": "^1.0.0-rc.12",
     "devalue": "^4.3.2",
+    "es-module-lexer": "^1.4.1",
     "fast-glob": "^3.3.2",
     "magic-string": "^0.30.5",
     "micromatch": "^4.0.5",

--- a/packages/rakkasjs/src/vite-plugin/index.ts
+++ b/packages/rakkasjs/src/vite-plugin/index.ts
@@ -1,4 +1,4 @@
-import { PluginOption, ResolvedConfig } from "vite";
+import { FilterPattern, PluginOption, ResolvedConfig } from "vite";
 import react, { Options as ReactPluginOptions } from "@vitejs/plugin-react";
 import { injectConfig } from "./inject-config";
 import { preventViteBuild } from "./prevent-vite-build";
@@ -14,6 +14,7 @@ import pageRoutes from "../features/pages/vite-plugin";
 import runServerSide from "../features/run-server-side/vite-plugin";
 import { adapters, RakkasAdapter } from "./adapters";
 import { babelTransformClientSidePages } from "../features/run-server-side/implementation/transform/transform-client-page";
+import { serverOnlyClientOnly } from "./server-only-client-only";
 
 export interface RakkasOptions {
 	/** Options passed to @vite/plugin-react */
@@ -40,6 +41,24 @@ export interface RakkasOptions {
 		| "bun"
 		| "lagon"
 		| RakkasAdapter;
+	/**
+	 * Filter patterns for server-only files that should not be included in the client bundle.
+	 *
+	 * @default { include: ["**\/*.server.*", "**\/server/**"] }
+	 */
+	serverOnlyFiles?: {
+		include?: FilterPattern;
+		exclude?: FilterPattern;
+	};
+	/**
+	 * Filter patterns for client-only files that should not be included in the server bundle.
+	 *
+	 * @default { include: ["**\/*.client.*", "**\/client/**"] }
+	 */
+	clientOnlyFiles?: {
+		include?: FilterPattern;
+		exclude?: FilterPattern;
+	};
 }
 
 export default function rakkas(options: RakkasOptions = {}): PluginOption[] {
@@ -135,6 +154,7 @@ export default function rakkas(options: RakkasOptions = {}): PluginOption[] {
 				}
 			},
 		}),
+		serverOnlyClientOnly(options),
 	];
 }
 

--- a/packages/rakkasjs/src/vite-plugin/server-only-client-only.ts
+++ b/packages/rakkasjs/src/vite-plugin/server-only-client-only.ts
@@ -1,0 +1,63 @@
+import { createFilter, type Plugin, type FilterPattern } from "vite";
+import { init, parse } from "es-module-lexer";
+
+export interface ServerOnlyClientOnlyOptions {
+	serverOnlyFiles?: {
+		include?: FilterPattern;
+		exclude?: FilterPattern;
+	};
+	clientOnlyFiles?: {
+		include?: FilterPattern;
+		exclude?: FilterPattern;
+	};
+}
+
+export function serverOnlyClientOnly(
+	options: ServerOnlyClientOnlyOptions = {},
+): Plugin {
+	const serverOnlyFilter = createFilter(
+		options.serverOnlyFiles?.include ?? ["**/*.server.*", "**/server/**"],
+		options.serverOnlyFiles?.exclude,
+	);
+
+	const clientOnlyFilter = createFilter(
+		options.clientOnlyFiles?.include ?? ["**/*.client.*", "**/client/**"],
+		options.clientOnlyFiles?.exclude,
+	);
+
+	return {
+		name: "rakkasjs:server-only-client-only",
+
+		enforce: "post",
+
+		async transform(code, id, options) {
+			await init;
+
+			if (
+				(options?.ssr && clientOnlyFilter(id)) ||
+				(!options?.ssr && serverOnlyFilter(id))
+			) {
+				if (id.match(/\.(?:css|scss|sass|less|styl|stylus)(?:\?|$)/)) {
+					return;
+				}
+
+				const [, exports] = parse(code);
+
+				let output =
+					"// This file is excluded from the " +
+					(options?.ssr ? "server" : "client") +
+					" bundle\n";
+				for (const { n } of exports) {
+					output +=
+						n === "default"
+							? "export default undefined;\n"
+							: `export const ${n} = undefined;\n`;
+				}
+
+				return {
+					code: output,
+				};
+			}
+		},
+	};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 4.2.1(vite@5.0.11)
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
     devDependencies:
       cross-env:
         specifier: ^7.0.3
@@ -38,7 +38,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.0(@types/node@20.11.1)
 
   examples/auth:
     dependencies:
@@ -69,7 +69,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -109,7 +109,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
 
   examples/empty:
     dependencies:
@@ -125,7 +125,7 @@ importers:
         version: link:../../packages/rakkasjs
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
 
   examples/express:
     dependencies:
@@ -156,7 +156,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -187,7 +187,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -221,7 +221,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
 
   examples/guide-samples:
     dependencies:
@@ -249,7 +249,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -280,7 +280,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -317,7 +317,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -348,7 +348,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
 
   examples/react-query:
     dependencies:
@@ -379,7 +379,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -410,7 +410,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -450,7 +450,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -490,7 +490,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-plugin-cjs-interop:
         specifier: ^2.0.2
         version: 2.0.2
@@ -533,13 +533,13 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
       vitest:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.0(@types/node@20.11.1)
 
   examples/urql:
     dependencies:
@@ -570,7 +570,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-tsconfig-paths:
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.3.3)(vite@5.0.11)
@@ -775,6 +775,9 @@ importers:
       devalue:
         specifier: ^4.3.2
         version: 4.3.2
+      es-module-lexer:
+        specifier: ^1.4.1
+        version: 1.4.1
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -856,7 +859,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
 
   testbed/kitchen-sink:
     dependencies:
@@ -984,7 +987,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
 
   website:
     dependencies:
@@ -1087,7 +1090,7 @@ importers:
         version: 6.0.1
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.11.1)
       vite-plugin-cjs-interop:
         specifier: ^2.0.2
         version: 2.0.2
@@ -2093,7 +2096,7 @@ packages:
       "@mdx-js/mdx": 3.0.0
       source-map: 0.7.4
       vfile: 6.0.1
-      vite: 5.0.11(@types/node@20.11.5)
+      vite: 5.0.11(@types/node@20.11.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6536,7 +6539,6 @@ packages:
       }
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /@types/node@20.11.5:
     resolution:
@@ -22490,30 +22492,6 @@ packages:
       vfile-message: 4.0.1
     dev: true
 
-  /vite-node@1.2.0:
-    resolution:
-      {
-        integrity: sha512-ETnQTHeAbbOxl7/pyBck9oAPZZZo+kYnFt1uQDD+hPReOc+wCjXw4r4jHriBRuVDB5isHmPXxrfc1yJnfBERqg==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4(supports-color@9.4.0)
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      vite: 5.0.11(@types/node@20.11.5)
-    transitivePeerDependencies:
-      - "@types/node"
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@1.2.0(@types/node@20.11.1):
     resolution:
       {
@@ -22564,7 +22542,7 @@ packages:
       debug: 4.3.4(supports-color@9.4.0)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.3.3)
-      vite: 5.0.11(@types/node@20.11.5)
+      vite: 5.0.11(@types/node@20.11.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22607,7 +22585,6 @@ packages:
       rollup: 4.9.5
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vite@5.0.11(@types/node@20.11.5):
     resolution:
@@ -22646,65 +22623,6 @@ packages:
       rollup: 4.9.5
     optionalDependencies:
       fsevents: 2.3.3
-
-  /vitest@1.2.0:
-    resolution:
-      {
-        integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-    hasBin: true
-    peerDependencies:
-      "@edge-runtime/vm": "*"
-      "@types/node": ^18.0.0 || >=20.0.0
-      "@vitest/browser": ^1.0.0
-      "@vitest/ui": ^1.0.0
-      happy-dom: "*"
-      jsdom: "*"
-    peerDependenciesMeta:
-      "@edge-runtime/vm":
-        optional: true
-      "@types/node":
-        optional: true
-      "@vitest/browser":
-        optional: true
-      "@vitest/ui":
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      "@vitest/expect": 1.2.0
-      "@vitest/runner": 1.2.0
-      "@vitest/snapshot": 1.2.0
-      "@vitest/spy": 1.2.0
-      "@vitest/utils": 1.2.0
-      acorn-walk: 8.3.2
-      cac: 6.7.14
-      chai: 4.4.1
-      debug: 4.3.4(supports-color@9.4.0)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.8.1
-      vite: 5.0.11(@types/node@20.11.5)
-      vite-node: 1.2.0
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
 
   /vitest@1.2.0(@types/node@20.11.1):
     resolution:

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1087,6 +1087,21 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 					document.body?.innerText.includes("2 * 5 = 10"),
 			);
 		});
+
+		test("server-only and client-only files are stripped", async () => {
+			await page.goto(host + "/only");
+
+			const body = (await page.waitForSelector("body"))!;
+			// Should be red
+			expect(await body.evaluate((e) => getComputedStyle(e).color)).toBe(
+				"rgb(255, 0, 0)",
+			);
+
+			await page.waitForSelector(".hydrated");
+			await page.waitForFunction(() =>
+				document.body?.innerText.includes("Pass"),
+			);
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/src/routes/only/asset.server.txt
+++ b/testbed/kitchen-sink/src/routes/only/asset.server.txt
@@ -1,0 +1,1 @@
+I'm a server only text asset file!

--- a/testbed/kitchen-sink/src/routes/only/client-only.client.ts
+++ b/testbed/kitchen-sink/src/routes/only/client-only.client.ts
@@ -1,0 +1,2 @@
+export const named = "client-only";
+export default "client-only";

--- a/testbed/kitchen-sink/src/routes/only/client/only.ts
+++ b/testbed/kitchen-sink/src/routes/only/client/only.ts
@@ -1,0 +1,2 @@
+export const named = "client-only";
+export default "client-only";

--- a/testbed/kitchen-sink/src/routes/only/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/only/index.page.tsx
@@ -1,0 +1,55 @@
+import { ClientOnly, useServerSideQuery } from "rakkasjs";
+import * as serverDot from "./server-only.server";
+import * as clientDot from "./client-only.client";
+import * as serverSlash from "./server/only";
+import * as clientSlash from "./client/only";
+import "./style.server.css";
+import text from "./asset.server.txt";
+
+export default function ClientOnlyServerOnlyPage() {
+	return (
+		<ClientOnly fallback={<p>Loading...</p>}>
+			<ClientOnlyServerOnly />
+		</ClientOnly>
+	);
+}
+
+function ClientOnlyServerOnly() {
+	const { data: server } = useServerSideQuery(() => ({
+		serverDot: { named: serverDot.named, default: serverDot.default },
+		clientDot: { named: clientDot.named, default: clientDot.default },
+		serverSlash: { named: serverSlash.named, default: serverSlash.default },
+		clientSlash: { named: clientSlash.named, default: clientSlash.default },
+		text,
+	}));
+
+	const client = {
+		serverDot: { named: serverDot.named, default: serverDot.default },
+		clientDot: { named: clientDot.named, default: clientDot.default },
+		serverSlash: { named: serverSlash.named, default: serverSlash.default },
+		clientSlash: { named: clientSlash.named, default: clientSlash.default },
+		text,
+	};
+
+	const pass =
+		server.serverDot.named &&
+		server.serverDot.default &&
+		!server.clientDot.named &&
+		!server.clientDot.default &&
+		client.clientDot.named &&
+		client.clientDot.default &&
+		!client.serverDot.named &&
+		!client.serverDot.default &&
+		server.serverSlash.named &&
+		server.serverSlash.default &&
+		!server.clientSlash.named &&
+		!server.clientSlash.default &&
+		client.clientSlash.named &&
+		client.clientSlash.default &&
+		!client.serverSlash.named &&
+		!client.serverSlash.default &&
+		server.text &&
+		!client.text;
+
+	return pass ? <p>Pass</p> : <p>Fail</p>;
+}

--- a/testbed/kitchen-sink/src/routes/only/server-only.server.ts
+++ b/testbed/kitchen-sink/src/routes/only/server-only.server.ts
@@ -1,0 +1,2 @@
+export const named = "server-only";
+export default "server-only";

--- a/testbed/kitchen-sink/src/routes/only/server/only.ts
+++ b/testbed/kitchen-sink/src/routes/only/server/only.ts
@@ -1,0 +1,2 @@
+export const named = "server-only";
+export default "server-only";

--- a/testbed/kitchen-sink/src/routes/only/style.server.css
+++ b/testbed/kitchen-sink/src/routes/only/style.server.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}


### PR DESCRIPTION
This PR implements server-only and client-only files.

Any module that matches the pattern `*.server.*` or `**/server/**` will have its exports turned into `undefined` in the client bundle. It is intended as an extra security layer to avoid exposing server secrets to the client.

Similarly, any module that matches the pattern `*.client.*` or `**/client/**` will have its exports turned into `undefined` in the server bundle. This is needed less often but it cn be handy for modules that use browser-only APIs at the module level, for example.

Style files (`.css`, `.scss` etc.) are not affected by this transform but asset files are.

The server-only and client-only file name patterns can be overridden with the `serverOnlyFiles` and `clientOnlyFiles` config options passed to the Rakkas Vite plugin.