### PR TITLE
feat: query tags

### DIFF
--- a/packages/rakkasjs/src/features/use-query/client-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/client-hooks.tsx
@@ -50,7 +50,7 @@ const cache: QueryCache = {
 		return key in queryCache || (typeof $RSC !== "undefined" && key in $RSC);
 	},
 
-	get(key: string) {
+	get(key: string, tags) {
 		if (!queryCache[key] && typeof $RSC !== "undefined" && key in $RSC) {
 			queryCache[key] = {
 				value: $RSC[key],
@@ -58,6 +58,7 @@ const cache: QueryCache = {
 				date: Date.now(),
 				hydrated: true,
 				cacheTime: DEFAULT_QUERY_OPTIONS.cacheTime,
+				tags: new Set(tags),
 			};
 
 			delete $RSC[key];
@@ -70,6 +71,7 @@ const cache: QueryCache = {
 		key: string,
 		valueOrPromise: any,
 		cacheTime = DEFAULT_QUERY_OPTIONS.cacheTime,
+		tags: string[] | Set<string>,
 	) {
 		if (valueOrPromise instanceof Promise) {
 			queryCache[key] ||= {
@@ -77,7 +79,9 @@ const cache: QueryCache = {
 				hydrated: false,
 				subscribers: new Set(),
 				cacheTime,
+				tags: new Set(tags),
 			};
+
 			queryCache[key] = {
 				...queryCache[key]!,
 				promise: valueOrPromise,
@@ -109,6 +113,7 @@ const cache: QueryCache = {
 				hydrated: false,
 				subscribers: new Set(),
 				cacheTime,
+				tags: new Set(tags),
 			};
 			queryCache[key] = {
 				...queryCache[key]!,
@@ -130,6 +135,7 @@ const cache: QueryCache = {
 			date: Date.now(),
 			hydrated: false,
 			cacheTime: DEFAULT_QUERY_OPTIONS.cacheTime,
+			tags: new Set([]),
 		};
 		queryCache[key]!.subscribers.add(fn);
 		if (queryCache[key]!.evictionTimeout !== undefined) {

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1102,6 +1102,27 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 				document.body?.innerText.includes("Pass"),
 			);
 		});
+
+		test("queries can be invalidated by tags", async () => {
+			await page.goto(host + "/query-tags");
+			await page.waitForSelector(".hydrated");
+
+			await page.waitForFunction(
+				() =>
+					document.body?.innerText.includes("data1: 0") &&
+					document.body?.innerText.includes("data2: 0") &&
+					document.body?.innerText.includes("data3: 0"),
+			);
+
+			await page.click("button");
+
+			await page.waitForFunction(
+				() =>
+					document.body?.innerText.includes("data1: 1") &&
+					document.body?.innerText.includes("data2: 0") &&
+					document.body?.innerText.includes("data3: 1"),
+			);
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/src/routes/query-tags/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/query-tags/index.page.tsx
@@ -1,0 +1,42 @@
+import { useMutation, useQuery } from "rakkasjs";
+
+export default function QueryTagsPage() {
+	const { data: data1 } = useQuery("tagged1", async () => counter1, {
+		tags: ["a", "b", "c"],
+	});
+
+	const { data: data2 } = useQuery("tagged2", async () => counter2, {
+		tags: ["x", "y", "z"],
+	});
+
+	const { data: data3 } = useQuery("tagged3", async () => counter3, {
+		tags: ["a", "x", "y"],
+	});
+
+	const { mutate } = useMutation(
+		async () => {
+			// Increment all but only invalidate data1 and data3
+			counter1++;
+			counter2++;
+			counter3++;
+		},
+		{
+			invalidateTags: ["a"],
+		},
+	);
+
+	return (
+		<div>
+			<p>data1: {data1}</p>
+			<p>data2: {data2}</p>
+			<p>data3: {data3}</p>
+			<p>
+				<button onClick={() => mutate()}>Mutate</button>
+			</p>
+		</div>
+	);
+}
+
+let counter1 = 0;
+let counter2 = 0;
+let counter3 = 0;


### PR DESCRIPTION
This PR implements query tags. Each query can have a set of tags (which are simple string values) and they can be invalidated by those tags.

Mutations can have an `invalidateTags` option, when provided, all queries that have any of those tags in their tag set will be invalidated when the mutation settles.

## Rationale

react-query has a hierarchical invalidation system based on array query keys. Currently, we only support string keys. I believe tags provide a more intuitive and flexible way to invalidate a set of queries that a hierarchical system.