### PR TITLE
feat!: remove @vitejs/plugin-react from Rakkas

### DIFF
--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "dotenv-cli": "^7.3.0",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",

--- a/examples/auth/vite.config.ts
+++ b/examples/auth/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
 
@@ -6,5 +7,5 @@ export default defineConfig({
 	ssr: {
 		external: ["@auth/core", "rakkasjs/node-adapter"],
 	},
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/emotion/package.json
+++ b/examples/emotion/package.json
@@ -12,6 +12,7 @@
     "@emotion/babel-plugin": "^11.11.0",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12"

--- a/examples/emotion/vite.config.ts
+++ b/examples/emotion/vite.config.ts
@@ -1,16 +1,16 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
 	plugins: [
-		rakkas({
-			react: {
-				jsxImportSource: "/src/emotion",
-				babel: {
-					plugins: ["@emotion/babel-plugin"],
-				},
+		react({
+			jsxImportSource: "/src/emotion",
+			babel: {
+				plugins: ["@emotion/babel-plugin"],
 			},
 		}),
+		rakkas(),
 	],
 	ssr: {
 		// This is required to fix ESM/CJS incompatibilities

--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/server/index.js"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "vite": "^5.0.12"
   },

--- a/examples/empty/vite.config.js
+++ b/examples/empty/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [rakkas()],
+	plugins: [react(), rakkas()],
 });

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -12,6 +12,7 @@
     "@types/express": "^4.17.21",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/express/vite.config.ts
+++ b/examples/express/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/fastify/vite.config.ts
+++ b/examples/fastify/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12"

--- a/examples/graphql/vite.config.ts
+++ b/examples/graphql/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [rakkas()],
+	plugins: [react(), rakkas()],
 });

--- a/examples/guide-samples/package.json
+++ b/examples/guide-samples/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/guide-samples/vite.config.ts
+++ b/examples/guide-samples/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/localized-urls/package.json
+++ b/examples/localized-urls/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/localized-urls/vite.config.ts
+++ b/examples/localized-urls/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/mantine/package.json
+++ b/examples/mantine/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "postcss-preset-mantine": "^1.12.3",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",

--- a/examples/mantine/vite.config.ts
+++ b/examples/mantine/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 	optimizeDeps: {
 		include: ["@mantine/core"],
 	},

--- a/examples/mdx/package.json
+++ b/examples/mdx/package.json
@@ -11,6 +11,7 @@
     "@cyco130/vite-plugin-mdx": "^1.0.4",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12"

--- a/examples/mdx/vite.config.ts
+++ b/examples/mdx/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import rakkas from "rakkasjs/vite-plugin";
 import { mdx } from "@cyco130/vite-plugin-mdx";
 
 export default defineConfig({
 	plugins: [
 		mdx(),
+		react(),
 		rakkas({
 			pageExtensions: ["jsx", "tsx", "mdx"],
 		}),

--- a/examples/react-query/package.json
+++ b/examples/react-query/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/react-query/vite.config.ts
+++ b/examples/react-query/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/server-sent-events/package.json
+++ b/examples/server-sent-events/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/server-sent-events/vite.config.ts
+++ b/examples/server-sent-events/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/session/package.json
+++ b/examples/session/package.json
@@ -12,6 +12,7 @@
     "@hattip/polyfills": "0.0.41",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/session/vite.config.ts
+++ b/examples/session/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig((env) => {
 	return {
-		plugins: [tsconfigPaths(), rakkas()],
+		plugins: [tsconfigPaths(), react(), rakkas()],
 	};
 });

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@types/styled-components": "^5.1.34",
+    "@vitejs/plugin-react": "^4.2.1",
     "babel-plugin-styled-components": "^2.1.4",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",

--- a/examples/styled-components/vite.config.ts
+++ b/examples/styled-components/vite.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 import { cjsInterop } from "vite-plugin-cjs-interop";
 
 export default defineConfig({
 	plugins: [
 		tsconfigPaths(),
-		rakkas({ react: { babel: { plugins: ["styled-components"] } } }),
+		react({ babel: { plugins: ["styled-components"] } }),
+		rakkas(),
 		cjsInterop({ dependencies: ["styled-components"] }),
 	],
 	optimizeDeps: {

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -17,6 +17,8 @@
     "@rakkasjs/eslint-config": "0.7.0-next.33",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react-swc": "^3.5.0",
     "eslint": "^8.56.0",
     "prettier": "^3.2.4",
     "rakkasjs": "0.7.0-next.33",

--- a/examples/todo/vite.config.ts
+++ b/examples/todo/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/examples/urql/package.json
+++ b/examples/urql/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
     "rakkasjs": "0.7.0-next.33",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",

--- a/examples/urql/vite.config.ts
+++ b/examples/urql/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
-import rakkas from "rakkasjs/vite-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [tsconfigPaths(), rakkas()],
+	plugins: [tsconfigPaths(), react(), rakkas()],
 });

--- a/packages/create-rakkas-app/scripts/create-templates.ts
+++ b/packages/create-rakkas-app/scripts/create-templates.ts
@@ -86,7 +86,7 @@ async function main() {
 	contents = contents
 		.replace(`tsconfigPaths(), `, "")
 		.replace(
-			/import tsconfigPaths from "vite-tsconfig-paths";/,
+			/import tsconfigPaths from "vite-tsconfig-paths";\r?\n/,
 			`import path from "node:path";\n`,
 		)
 		.replace(

--- a/packages/create-rakkas-app/src/generate.ts
+++ b/packages/create-rakkas-app/src/generate.ts
@@ -104,6 +104,12 @@ async function copyFiles(dir: string, options: Options, command: string) {
 		fs.readFileSync(dir + "/package.json", "utf8"),
 	) as DeepPartial<typeof import("../../../examples/todo/package.json")>;
 
+	if (options.swc) {
+		delete pkg.devDependencies!["@vitejs/plugin-react"];
+	} else {
+		delete pkg.devDependencies!["@vitejs/plugin-react-swc"];
+	}
+
 	if (!options.typescript) {
 		delete pkg.scripts!["test:typecheck"];
 	}
@@ -143,6 +149,16 @@ async function copyFiles(dir: string, options: Options, command: string) {
 		JSON.stringify(pkg, undefined, 2),
 		"utf8",
 	);
+
+	if (options.swc) {
+		const ext = options.typescript ? "ts" : "js";
+		let viteConfig = fs.readFileSync(dir + "/vite.config." + ext, "utf8");
+		viteConfig = viteConfig.replace(
+			/@vitejs\/plugin-react/,
+			"@vitejs/plugin-react-swc",
+		);
+		fs.writeFileSync(dir + "/vite.config." + ext, viteConfig, "utf8");
+	}
 
 	if (!options.demo) {
 		await mkdirp(dir + "/src/routes");

--- a/packages/create-rakkas-app/src/index.ts
+++ b/packages/create-rakkas-app/src/index.ts
@@ -12,6 +12,7 @@ export interface Options {
 	skipPrompt?: boolean;
 	force?: boolean;
 
+	swc?: boolean;
 	typescript?: boolean;
 	prettier?: boolean;
 	eslint?: boolean;
@@ -25,6 +26,11 @@ cli
 	.option(
 		"-f, --force",
 		"[boolean] Generate even if the directory is not empty",
+	)
+	.option(
+		"-s, --swc",
+		"[boolean] Use @vitejs/plugin-react-swc (faster) instead of @vitejs/plugin-react (smaller)",
+		{ default: false },
 	)
 	.option("-t, --typescript", "[boolean] Use TypeScript for static typing", {
 		default: true,
@@ -97,6 +103,12 @@ async function prompt(options: Options) {
 			pageSize: Infinity,
 			choices: [
 				{
+					name: " @vitejs/plugin-react-swc for faster builds",
+					short: "SWC",
+					value: "swc",
+					checked: options.swc,
+				},
+				{
 					name: " TypeScript for static typing",
 					short: "TypeScript",
 					value: "typescript",
@@ -130,6 +142,7 @@ async function prompt(options: Options) {
 		},
 	]);
 
+	options.swc = answers.features.includes("swc");
 	options.typescript = answers.features.includes("typescript");
 	options.prettier = answers.features.includes("prettier");
 	options.eslint = answers.features.includes("eslint");

--- a/packages/rakkasjs/package.json
+++ b/packages/rakkasjs/package.json
@@ -93,7 +93,6 @@
     "@vavite/expose-vite-dev-server": "4.0.2",
     "@vavite/multibuild": "^4.0.2",
     "@vavite/node-loader": "^4.0.2",
-    "@vitejs/plugin-react": "^4.2.1",
     "cac": "^6.7.14",
     "cheerio": "^1.0.0-rc.12",
     "devalue": "^4.3.2",

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -17,15 +17,16 @@ import {
 	PreloadContext,
 	PreloadResult,
 } from "./page-types";
-import prodRoutes, {
-	notFoundRoutes as prodNotFoundRoutes,
-} from "virtual:rakkasjs:client-page-routes";
 import { Default404Page } from "../features/pages/Default404Page";
 import { Head, LookupHookResult, PageContext, Redirect } from "../lib";
 import { IsomorphicContext } from "./isomorphic-context";
 import { createNamedContext } from "./named-context";
 import { prefetcher } from "../features/client-side-navigation/implementation";
 import { RouteParamsContext } from "../features/pages/route-params-context";
+
+type Routes = (typeof import("virtual:rakkasjs:client-page-routes"))["default"];
+type NotFoundRoutes =
+	(typeof import("virtual:rakkasjs:client-page-routes"))["notFoundRoutes"];
 
 export interface AppProps {
 	beforePageLookupHandlers: Array<
@@ -192,14 +193,15 @@ export async function loadRoute(
 	let updatedComponents: Layout[] | undefined;
 
 	if (!found || import.meta.hot) {
-		let routes: typeof prodRoutes;
-		let updatedRoutes: typeof prodRoutes;
-		let notFoundRoutes: typeof prodNotFoundRoutes;
-		let updatedNotFoundRoutes: typeof prodNotFoundRoutes;
+		let routes: Routes;
+		let updatedRoutes: Routes;
+		let notFoundRoutes: NotFoundRoutes;
+		let updatedNotFoundRoutes: NotFoundRoutes;
 
 		if (import.meta.env.PROD) {
-			routes = prodRoutes;
-			notFoundRoutes = prodNotFoundRoutes;
+			const prodModule = await import("virtual:rakkasjs:client-page-routes");
+			routes = prodModule.default;
+			notFoundRoutes = prodModule.notFoundRoutes;
 		} else {
 			// This whole dance is about rendering the old component (which
 			// React updates internally via Fast Refresh), but calling the

--- a/packages/rakkasjs/src/vite-plugin/inject-config.ts
+++ b/packages/rakkasjs/src/vite-plugin/inject-config.ts
@@ -159,10 +159,10 @@ export function injectConfig(options: InjectConfigOptions): Plugin {
 
 			config.configFileDependencies.push(...routeConfigFiles);
 
+			// TODO: Clean this mess up!
 			// Illegally write to the config object
 			// Rakkas will only access these late in the process
 			const writable = config as unknown as UserConfig;
-
 			writable.api = writable.api || {};
 			writable.api.rakkas = writable.api.rakkas || {};
 			writable.api.rakkas.routeConfigs = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       dotenv-cli:
         specifier: ^7.3.0
         version: 7.3.0
@@ -101,6 +104,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -120,6 +126,9 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -148,6 +157,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -179,6 +191,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -213,6 +228,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -241,6 +259,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -272,6 +293,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -306,6 +330,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       postcss-preset-mantine:
         specifier: ^1.12.3
         version: 1.12.3(postcss@8.4.33)
@@ -340,6 +367,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -371,6 +401,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -402,6 +435,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -442,6 +478,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -479,6 +518,9 @@ importers:
       "@types/styled-components":
         specifier: ^5.1.34
         version: 5.1.34
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       babel-plugin-styled-components:
         specifier: ^2.1.4
         version: 2.1.4(@babel/core@7.23.7)(styled-components@6.1.8)
@@ -519,6 +561,12 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
+      "@vitejs/plugin-react-swc":
+        specifier: ^3.5.0
+        version: 3.5.0(vite@5.0.12)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -562,6 +610,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       rakkasjs:
         specifier: 0.7.0-next.33
         version: link:../../packages/rakkasjs
@@ -763,9 +814,6 @@ importers:
       "@vavite/node-loader":
         specifier: ^4.0.2
         version: 4.0.2(vite@5.0.12)
-      "@vitejs/plugin-react":
-        specifier: ^4.2.1
-        version: 4.2.1(vite@5.0.12)
       cac:
         specifier: ^6.7.14
         version: 6.7.14
@@ -912,6 +960,12 @@ importers:
       "@types/ps-tree":
         specifier: ^1.1.6
         version: 1.1.6
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
+      "@vitejs/plugin-react-swc":
+        specifier: ^3.5.0
+        version: 3.5.0(vite@5.0.12)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -967,6 +1021,9 @@ importers:
       "@types/ps-tree":
         specifier: ^1.1.6
         version: 1.1.6
+      "@vitejs/plugin-react":
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.12)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -1046,6 +1103,9 @@ importers:
       "@types/react-dom":
         specifier: ^18.2.18
         version: 18.2.18
+      "@vitejs/plugin-react-swc":
+        specifier: ^3.5.0
+        version: 3.5.0(vite@5.0.12)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -1756,7 +1816,6 @@ packages:
     dependencies:
       "@babel/core": 7.23.7
       "@babel/helper-plugin-utils": 7.22.5
-    dev: false
 
   /@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.7):
     resolution:
@@ -1769,7 +1828,6 @@ packages:
     dependencies:
       "@babel/core": 7.23.7
       "@babel/helper-plugin-utils": 7.22.5
-    dev: false
 
   /@babel/plugin-transform-typescript@7.23.6(@babel/core@7.23.7):
     resolution:
@@ -5845,6 +5903,168 @@ packages:
       }
     dev: false
 
+  /@swc/core-darwin-arm64@1.3.105:
+    resolution:
+      {
+        integrity: sha512-buWeweLVDXXmcnfIemH4PGnpjwsDTUGitnPchdftb0u1FU8zSSP/lw/pUCBDG/XvWAp7c/aFxgN4CyG0j7eayA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.3.105:
+    resolution:
+      {
+        integrity: sha512-hFmXPApqjA/8sy/9NpljHVaKi1OvL9QkJ2MbbTCCbJERuHMpMUeMBUWipHRfepGHFhU+9B9zkEup/qJaJR4XIg==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf@1.3.105:
+    resolution:
+      {
+        integrity: sha512-mwXyMC41oMKkKrPpL8uJpOxw7fyfQoVtIw3Y5p0Blabk+espNYqix0E8VymHdRKuLmM//z5wVmMsuHdGBHvZeg==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.3.105:
+    resolution:
+      {
+        integrity: sha512-H7yEIVydnUtqBSUxwmO6vpIQn7j+Rr0DF6ZOORPyd/SFzQJK9cJRtmJQ3ZMzlJ1Bb+1gr3MvjgLEnmyCYEm2Hg==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.3.105:
+    resolution:
+      {
+        integrity: sha512-Jg7RTFT3pGFdGt5elPV6oDkinRy7q9cXpenjXnJnM2uvx3jOwnsAhexPyCDHom8SHL0j+9kaLLC66T3Gz1E4UA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.3.105:
+    resolution:
+      {
+        integrity: sha512-DJghplpyusAmp1X5pW/y93MmS/u83Sx5GrpJxI6KLPa82+NItTgMcl8KBQmW5GYAJpVKZyaIvBanS5TdR8aN2w==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.3.105:
+    resolution:
+      {
+        integrity: sha512-wD5jL2dZH/5nPNssBo6jhOvkI0lmWnVR4vnOXWjuXgjq1S0AJpO5jdre/6pYLmf26hft3M42bteDnjR4AAZ38w==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.3.105:
+    resolution:
+      {
+        integrity: sha512-UqJtwILUHRw2+3UTPnRkZrzM/bGdQtbR4UFdp79mZQYfryeOUVNg7aJj/bWUTkKtLiZ3o+FBNrM/x2X1mJX5bA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.3.105:
+    resolution:
+      {
+        integrity: sha512-Z95C6vZgBEJ1snidYyjVKnVWiy/ZpPiIFIXGWkDr4ZyBgL3eZX12M6LzZ+NApHKffrbO4enbFyFomueBQgS2oA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.3.105:
+    resolution:
+      {
+        integrity: sha512-3J8fkyDPFsS3mszuYUY4Wfk7/B2oio9qXUwF3DzOs2MK+XgdyMLIptIxL7gdfitXJBH8k39uVjrIw1JGJDjyFA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core@1.3.105:
+    resolution:
+      {
+        integrity: sha512-me2VZyr3OjqRpFrYQJJYy7x/zbFSl9nt+MAGnIcBtjDsN00iTVqEaKxBjPBFQV9BDAgPz2SRWes/DhhVm5SmMw==,
+      }
+    engines: { node: ">=10" }
+    requiresBuild: true
+    peerDependencies:
+      "@swc/helpers": ^0.5.0
+    peerDependenciesMeta:
+      "@swc/helpers":
+        optional: true
+    dependencies:
+      "@swc/counter": 0.1.2
+      "@swc/types": 0.1.5
+    optionalDependencies:
+      "@swc/core-darwin-arm64": 1.3.105
+      "@swc/core-darwin-x64": 1.3.105
+      "@swc/core-linux-arm-gnueabihf": 1.3.105
+      "@swc/core-linux-arm64-gnu": 1.3.105
+      "@swc/core-linux-arm64-musl": 1.3.105
+      "@swc/core-linux-x64-gnu": 1.3.105
+      "@swc/core-linux-x64-musl": 1.3.105
+      "@swc/core-win32-arm64-msvc": 1.3.105
+      "@swc/core-win32-ia32-msvc": 1.3.105
+      "@swc/core-win32-x64-msvc": 1.3.105
+    dev: true
+
+  /@swc/counter@0.1.2:
+    resolution:
+      {
+        integrity: sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==,
+      }
+    dev: true
+
+  /@swc/types@0.1.5:
+    resolution:
+      {
+        integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==,
+      }
+    dev: true
+
   /@szmarczak/http-timer@5.0.1:
     resolution:
       {
@@ -6735,6 +6955,20 @@ packages:
       - supports-color
     dev: false
 
+  /@vitejs/plugin-react-swc@3.5.0(vite@5.0.12):
+    resolution:
+      {
+        integrity: sha512-1PrOvAaDpqlCV+Up8RkAh9qaiUjoDUcjtttyhXDKw53XA6Ve16SOp6cCOpRs8Dj8DqUQs6eTW5YkLcLJjrXAig==,
+      }
+    peerDependencies:
+      vite: ^4 || ^5
+    dependencies:
+      "@swc/core": 1.3.105
+      vite: 5.0.12(@types/node@20.11.5)
+    transitivePeerDependencies:
+      - "@swc/helpers"
+    dev: true
+
   /@vitejs/plugin-react@4.2.1(vite@5.0.12):
     resolution:
       {
@@ -6752,7 +6986,6 @@ packages:
       vite: 5.0.12(@types/node@20.11.5)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@vitest/expect@1.2.1:
     resolution:
@@ -18091,7 +18324,6 @@ packages:
         integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==,
       }
     engines: { node: ">=0.10.0" }
-    dev: false
 
   /react-remove-scroll-bar@2.3.4(@types/react@18.2.48)(react@18.2.0):
     resolution:

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -35,8 +35,22 @@ if (import.meta.env.TEST_HOST) {
 		testCase("Development Mode", true, TEST_HOST, "pnpm dev");
 	}
 
+	if (include.includes("dev-swc")) {
+		testCase("Development Mode with SWC", true, TEST_HOST, "pnpm dev", true);
+	}
+
 	if (include.includes("prod")) {
 		testCase("Production Mode", false, TEST_HOST, "pnpm build && pnpm start");
+	}
+
+	if (include.includes("prod-swc")) {
+		testCase(
+			"Production Mode with SWC",
+			false,
+			TEST_HOST,
+			"pnpm build && pnpm start",
+			true,
+		);
 	}
 
 	const nodeVersions = process.versions.node.split(".");
@@ -97,7 +111,13 @@ const browser = await puppeteer.launch({
 const pages = await browser.pages();
 const page = pages[0];
 
-function testCase(title: string, dev: boolean, host: string, command?: string) {
+function testCase(
+	title: string,
+	dev: boolean,
+	host: string,
+	command?: string,
+	swc?: boolean,
+) {
 	describe(title, () => {
 		if (command) {
 			let cp: ChildProcess | undefined;
@@ -111,6 +131,7 @@ function testCase(title: string, dev: boolean, host: string, command?: string) {
 						...process.env,
 						BROWSER: "none",
 						HOST: "127.0.0.1",
+						USE_SWC: swc ? "1" : undefined,
 					},
 				});
 

--- a/testbed/kitchen-sink/package.json
+++ b/testbed/kitchen-sink/package.json
@@ -25,6 +25,8 @@
     "@hattip/adapter-netlify-edge": "0.0.41",
     "@hattip/adapter-netlify-functions": "0.0.41",
     "@types/ps-tree": "^1.1.6",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react-swc": "^3.5.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "node-fetch": "^3.3.2",

--- a/testbed/kitchen-sink/vite.config.ts
+++ b/testbed/kitchen-sink/vite.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import reactSwc from "@vitejs/plugin-react-swc";
 import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
@@ -6,6 +8,7 @@ export default defineConfig({
 		host: "127.0.0.1",
 	},
 	plugins: [
+		process.env.USE_SWC ? reactSwc() : react(),
 		rakkas({
 			adapter: (process.env.RAKKAS_TARGET as any) || "node",
 			prerender: ["/prerender"],

--- a/testbed/static/package.json
+++ b/testbed/static/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@cyco130/eslint-config": "^3.6.2",
     "@types/ps-tree": "^1.1.6",
+    "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.56.0",
     "node-fetch": "^3.3.2",
     "ps-tree": "^1.2.0",

--- a/testbed/static/vite.config.ts
+++ b/testbed/static/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import rakkas from "rakkasjs/vite-plugin";
 
 export default defineConfig({
-	plugins: [rakkas({ prerender: true })],
+	plugins: [react(), rakkas({ prerender: true })],
 });

--- a/website/package.json
+++ b/website/package.json
@@ -40,6 +40,7 @@
     "@types/cookie": "^0.6.0",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react-swc": "^3.5.0",
     "eslint": "^8.56.0",
     "gray-matter": "^4.0.3",
     "install": "^0.13.0",

--- a/website/src/routes/_site/guide/getting-started.page.mdx
+++ b/website/src/routes/_site/guide/getting-started.page.mdx
@@ -25,10 +25,22 @@ yarn create rakkas-app my-rakkas-app
 >
 > ```bash
 > npm install --save react react-dom
-> npm install --save-dev vite rakkasjs
+> npm install --save-dev rakkasjs vite @vitejs/plugin-react # or @vitejs/plugin-react-swc
 > ```
 >
-> Then create a `src/routes/index.page.jsx` file like this:
+> Then create a `vite.config.js` file like this:
+>
+> ```js
+> import { defineConfig } from "vite";
+> import react from "@vitejs/plugin-react";
+> import rakkas from "rakkasjs/vite-plugin";
+>
+> export default defineConfig({
+>   plugins: [react(), rakkas()],
+> });
+> ```
+>
+> And finally create a `src/routes/index.page.jsx` file like this:
 >
 > ```jsx
 > export default function HomePage() {

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
 import rakkas from "rakkasjs/vite-plugin";
 import codeViewer from "./vite-plugins/code-viewer";
 import sampleLoader from "./vite-plugins/sample-loader";
@@ -47,6 +48,8 @@ export default defineConfig({
 			rehypePlugins: [rhypePrism],
 			providerImportSource: "@mdx-js/react",
 		}),
+
+		react(),
 
 		rakkas({
 			pageExtensions: ["jsx", "tsx", "mdx"],


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE**

This PR removes `@vitejs/plugin-react` from Rakkas to allow users to select between `@vitejs/plugin-react` (smaller) and `@vitejs/plugin-react-swc` (faster). It's also possible to not use either of them but that will disable Fast Refresh.

This change requires updating the Vite config. The React plugin should come _before_ the Rakkas plugin:

```diff
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react"; // or @vitejs/plugin-react-swc
 import rakkas from "rakkasjs/vite-plugin";

 export default defineConfig({
   plugins: [
+    react({ /* @vitejs/plugin-react options */ }),
     rakkas({
-      react: { /* @vitejs/plugin-react options */ },
     }),
   ],
 });
```

