### PR TITLE
fix!: remove circular dependencies that prevent HMR

### DIFF
--- a/examples/auth/src/entry-hattip.ts
+++ b/examples/auth/src/entry-hattip.ts
@@ -1,4 +1,4 @@
-import { createRequestHandler, PageLocals } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 import { Auth } from "@auth/core";
 import type { Provider } from "@auth/core/providers";
 import GitHubProvider from "@auth/core/providers/github";

--- a/examples/express/src/entry-hattip.ts
+++ b/examples/express/src/entry-hattip.ts
@@ -1,3 +1,3 @@
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 
 export default createRequestHandler();

--- a/examples/fastify/src/entry-hattip.ts
+++ b/examples/fastify/src/entry-hattip.ts
@@ -1,3 +1,3 @@
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 
 export default createRequestHandler();

--- a/examples/graphql/src/entry-hattip.ts
+++ b/examples/graphql/src/entry-hattip.ts
@@ -1,5 +1,6 @@
-import { createRequestHandler, RequestContext } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 import { yoga, createSchema } from "@hattip/graphql";
+import type { RequestContext } from "rakkasjs";
 
 let yogaMiddleware: ReturnType<typeof yoga> | undefined;
 

--- a/examples/mantine/src/entry-hattip.tsx
+++ b/examples/mantine/src/entry-hattip.tsx
@@ -1,4 +1,4 @@
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 import { ColorSchemeScript } from "@mantine/core";
 
 export default createRequestHandler({

--- a/examples/react-query/src/entry-client.tsx
+++ b/examples/react-query/src/entry-client.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-import { startClient } from "rakkasjs";
+import { startClient } from "rakkasjs/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 function setQueryData(data: Record<string, unknown>) {

--- a/examples/react-query/src/entry-hattip.tsx
+++ b/examples/react-query/src/entry-hattip.tsx
@@ -1,9 +1,5 @@
-import { createRequestHandler } from "rakkasjs";
-import {
-	QueryCache,
-	QueryClient,
-	QueryClientProvider,
-} from "@tanstack/react-query";
+import { createRequestHandler } from "rakkasjs/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { uneval } from "devalue";
 
 declare module "rakkasjs" {

--- a/examples/session/src/entry-hattip.ts
+++ b/examples/session/src/entry-hattip.ts
@@ -1,4 +1,4 @@
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 import { cookie } from "@hattip/cookie";
 import { session, EncryptedCookieStore } from "@hattip/session";
 

--- a/examples/styled-components/src/entry-hattip.tsx
+++ b/examples/styled-components/src/entry-hattip.tsx
@@ -1,4 +1,4 @@
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 import { ServerStyleSheet } from "styled-components";
 
 export default createRequestHandler({

--- a/examples/urql/src/entry-client.tsx
+++ b/examples/urql/src/entry-client.tsx
@@ -1,4 +1,4 @@
-import { startClient } from "rakkasjs";
+import { startClient } from "rakkasjs/client";
 import {
 	createClient,
 	dedupExchange,

--- a/examples/urql/src/entry-hattip.tsx
+++ b/examples/urql/src/entry-hattip.tsx
@@ -1,4 +1,4 @@
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 import {
 	createClient,
 	cacheExchange,

--- a/packages/rakkasjs/package.json
+++ b/packages/rakkasjs/package.json
@@ -18,9 +18,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "browser": "./dist/client.js",
-      "default": "./dist/server.js"
+      "browser": "./dist/index.client.js",
+      "default": "./dist/index.server.js"
     },
+    "./client": "./dist/client.js",
+    "./server": "./dist/server.js",
     "./node-adapter": "./dist/node-adapter.js",
     "./vite-plugin": "./dist/vite-plugin.js",
     "./node-loader": "./node-loader.mjs",

--- a/packages/rakkasjs/src/features/async-local-request-context/server-hooks.ts
+++ b/packages/rakkasjs/src/features/async-local-request-context/server-hooks.ts
@@ -1,4 +1,4 @@
-import { ServerHooks } from "../../lib";
+import type { ServerHooks } from "../../runtime/hattip-handler";
 import { requestContextStorage } from "./implementation";
 
 const asyncLocalRequestContextServerHooks: ServerHooks = {

--- a/packages/rakkasjs/src/features/error-boundary/implementation.tsx
+++ b/packages/rakkasjs/src/features/error-boundary/implementation.tsx
@@ -1,9 +1,7 @@
 import React, { FC, PropsWithChildren } from "react";
-import {
-	ErrorBoundaryProps,
-	ErrorBoundary as OriginalErrorBoundary,
-} from "react-error-boundary";
+import { ErrorBoundary as OriginalErrorBoundary } from "react-error-boundary";
 import { resetErrors } from "../use-query/client-hooks";
+import type { ErrorBoundaryProps } from "./lib";
 
 /** @see https://github.com/bvaughn/react-error-boundary */
 export const ErrorBoundary: FC<PropsWithChildren<ErrorBoundaryProps>> = (

--- a/packages/rakkasjs/src/features/error-boundary/lib.ts
+++ b/packages/rakkasjs/src/features/error-boundary/lib.ts
@@ -1,3 +1,12 @@
+import type {
+	Component,
+	ComponentType,
+	ErrorInfo,
+	FunctionComponent,
+	PropsWithChildren,
+	ReactElement,
+	ReactNode,
+} from "react";
 export type {
 	ErrorBoundaryProps,
 	ErrorBoundaryPropsWithComponent,
@@ -5,10 +14,68 @@ export type {
 	ErrorBoundaryPropsWithRender,
 	FallbackProps,
 	UseErrorBoundaryApi,
-} from "react-error-boundary";
+};
 
-export { useErrorBoundary } from "react-error-boundary";
+import { useErrorBoundary as originalUseErrorBoundary } from "react-error-boundary";
 
 export { ErrorBoundary } from "./implementation";
 
+export const useErrorBoundary: <TError = any>() => UseErrorBoundaryApi<TError> =
+	originalUseErrorBoundary;
+
 // TODO: withErrorBoundary?
+
+type FallbackProps = {
+	error: any;
+	resetErrorBoundary: (...args: any[]) => void;
+};
+
+type ErrorBoundarySharedProps = PropsWithChildren<{
+	onError?: (error: Error, info: ErrorInfo) => void;
+	onReset?: (
+		details:
+			| {
+					reason: "imperative-api";
+					args: any[];
+			  }
+			| {
+					reason: "keys";
+					prev: any[] | undefined;
+					next: any[] | undefined;
+			  },
+	) => void;
+	resetKeys?: any[];
+}>;
+
+type ErrorBoundaryPropsWithComponent = ErrorBoundarySharedProps & {
+	fallback?: never;
+	FallbackComponent: ComponentType<FallbackProps>;
+	fallbackRender?: never;
+};
+
+type ErrorBoundaryPropsWithRender = ErrorBoundarySharedProps & {
+	fallback?: never;
+	FallbackComponent?: never;
+	fallbackRender: FallbackRender;
+};
+
+type ErrorBoundaryPropsWithFallback = ErrorBoundarySharedProps & {
+	fallback: ReactElement<
+		unknown,
+		string | FunctionComponent | typeof Component
+	> | null;
+	FallbackComponent?: never;
+	fallbackRender?: never;
+};
+
+type ErrorBoundaryProps =
+	| ErrorBoundaryPropsWithFallback
+	| ErrorBoundaryPropsWithComponent
+	| ErrorBoundaryPropsWithRender;
+
+type UseErrorBoundaryApi<TError> = {
+	resetBoundary: () => void;
+	showBoundary: (error: TError) => void;
+};
+
+type FallbackRender = (props: FallbackProps) => ReactNode;

--- a/packages/rakkasjs/src/features/pages/middleware.tsx
+++ b/packages/rakkasjs/src/features/pages/middleware.tsx
@@ -18,7 +18,7 @@ import {
 	IsomorphicContext,
 	ServerSideContext,
 } from "../../runtime/isomorphic-context";
-import { PageContext } from "../use-query/implementation";
+import type { PageContext } from "../../runtime/page-types";
 import { Default404Page } from "./Default404Page";
 import commonHooks from "virtual:rakkasjs:common-hooks";
 import {

--- a/packages/rakkasjs/src/features/run-server-side/lib-common.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-common.ts
@@ -2,7 +2,6 @@ import { stringify } from "@brillout/json-serializer/stringify";
 import type { RequestContext } from "@hattip/compose";
 import { FormEvent, useContext } from "react";
 import {
-	ActionResult,
 	UseMutationErrorResult,
 	UseMutationIdleResult,
 	UseMutationLoadingResult,
@@ -12,7 +11,8 @@ import {
 } from "../../lib";
 import { ServerSideContext } from "../../runtime/isomorphic-context";
 import { encodeFileNameSafe } from "../../runtime/utils";
-import { UseQueryOptions } from "../use-query/implementation";
+import type { UseQueryOptions } from "../use-query/implementation";
+import type { ActionResult } from "../../runtime/page-types";
 
 /**
  * Hook for getting the request context. Returns undefined on the client.

--- a/packages/rakkasjs/src/features/run-server-side/lib-server.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-server.ts
@@ -8,10 +8,13 @@ import {
 	UseServerSideQueryOptions,
 } from "./lib-common";
 import { uneval } from "devalue";
-import { RequestContext } from "@hattip/compose";
-import { UseMutationOptions, UseMutationResult } from "../use-mutation/lib";
+import type { RequestContext } from "@hattip/compose";
+import type {
+	UseMutationOptions,
+	UseMutationResult,
+} from "../use-mutation/lib";
 import { encodeFileNameSafe } from "../../runtime/utils";
-import { EventSourceResult } from "../use-query/implementation";
+import type { EventSourceResult } from "../use-query/implementation";
 
 function runSSQImpl(
 	ctx: RequestContext,

--- a/packages/rakkasjs/src/features/use-query/implementation.ts
+++ b/packages/rakkasjs/src/features/use-query/implementation.ts
@@ -1,6 +1,4 @@
 /// <reference types="vite/client" />
-
-import type { RequestContext } from "@hattip/compose";
 import {
 	useCallback,
 	useContext,
@@ -10,13 +8,14 @@ import {
 	useState,
 	useSyncExternalStore,
 } from "react";
-import { PageLocals, useErrorBoundary } from "../../lib";
+import { useErrorBoundary } from "../../lib";
 import { IsomorphicContext } from "../../runtime/isomorphic-context";
 import { createNamedContext } from "../../runtime/named-context";
 import {
 	EventStreamContentType,
 	fetchEventSource,
 } from "@microsoft/fetch-event-source";
+import type { PageContext } from "../../runtime/page-types";
 
 export interface CacheItem {
 	value?: any;
@@ -161,22 +160,6 @@ export const DEFAULT_QUERY_OPTIONS: RequiredUseQueryOptions = {
 	keepPreviousData: false,
 	tags: [],
 };
-
-/** Context within which the page is being rendered */
-export interface PageContext {
-	/** URL */
-	url: URL;
-	/** Isomorphic fetch function */
-	fetch: typeof fetch;
-	/** Query client used by useQuery */
-	queryClient: QueryClient;
-	/** Request context, only defined on the server */
-	requestContext?: RequestContext;
-	/** Application-specific stuff */
-	locals: PageLocals;
-	/** Page action data */
-	actionData?: any;
-}
 
 export function usePageContext(): PageContext {
 	return useContext(IsomorphicContext);

--- a/packages/rakkasjs/src/features/use-query/lib.ts
+++ b/packages/rakkasjs/src/features/use-query/lib.ts
@@ -2,7 +2,6 @@ export type {
 	UseQueryOptions,
 	QueryResult,
 	QueryFn,
-	PageContext,
 	QueryClient,
 } from "./implementation";
 export {

--- a/packages/rakkasjs/src/lib/index.client.ts
+++ b/packages/rakkasjs/src/lib/index.client.ts
@@ -14,8 +14,6 @@ export {
 	useFormMutation,
 } from "../features/run-server-side/lib-client";
 
-export { startClient } from "../runtime/client-entry";
-
 export * from "../features/pages/lib";
 
 export { getRequestContext } from "../features/async-local-request-context/lib-client";

--- a/packages/rakkasjs/src/lib/index.server.ts
+++ b/packages/rakkasjs/src/lib/index.server.ts
@@ -14,8 +14,6 @@ export {
 	useFormMutation,
 } from "../features/run-server-side/lib-server";
 
-export { createRequestHandler } from "../runtime/hattip-handler";
-
 export * from "../features/pages/lib";
 
 export { getRequestContext } from "../features/async-local-request-context/lib-server";

--- a/packages/rakkasjs/src/lib/index.ts
+++ b/packages/rakkasjs/src/lib/index.ts
@@ -21,6 +21,7 @@ export type {
 	RouteConfigExport,
 	RouteConfig,
 	BaseRouteConfig,
+	PageContext,
 } from "../runtime/page-types";
 
 export * from "../runtime/common-hooks";
@@ -48,17 +49,5 @@ export type {
 	useSSM,
 	useFormMutation,
 } from "../features/run-server-side/lib-client";
-
-export type {
-	startClient,
-	ClientHooks,
-	StartClientOptions,
-} from "../runtime/client-entry";
-
-export type {
-	createRequestHandler,
-	ServerHooks,
-	PageRequestHooks as PageHooks,
-} from "../runtime/hattip-handler";
 
 export type { getRequestContext } from "../features/async-local-request-context/lib-server";

--- a/packages/rakkasjs/src/runtime/client-entry.tsx
+++ b/packages/rakkasjs/src/runtime/client-entry.tsx
@@ -1,18 +1,14 @@
 import React, { StrictMode, Suspense } from "react";
 import { hydrateRoot, createRoot } from "react-dom/client";
 import { DEFAULT_QUERY_OPTIONS } from "../features/use-query/implementation";
-import {
-	UseQueryOptions,
-	PageContext,
-	ErrorBoundary,
-	LookupHookResult,
-} from "../lib";
+import { UseQueryOptions, ErrorBoundary, LookupHookResult } from "../lib";
 import { App, loadRoute, RouteContext } from "./App";
 import { ClientHooks } from "./client-hooks";
 import featureHooks from "./feature-client-hooks";
 import { IsomorphicContext } from "./isomorphic-context";
 import ErrorComponent from "virtual:rakkasjs:error-page";
 import commonHooks from "virtual:rakkasjs:common-hooks";
+import { PageContext } from "./page-types";
 
 export type { ClientHooks };
 

--- a/packages/rakkasjs/src/runtime/client-hooks.ts
+++ b/packages/rakkasjs/src/runtime/client-hooks.ts
@@ -1,5 +1,5 @@
 import { ReactElement } from "react";
-import { PageContext } from "../lib";
+import { PageContext } from "../runtime/page-types";
 
 /** Client-side customization hooks */
 export interface ClientHooks {

--- a/packages/rakkasjs/src/runtime/common-hooks.ts
+++ b/packages/rakkasjs/src/runtime/common-hooks.ts
@@ -1,5 +1,5 @@
 import { ReactElement } from "react";
-import { PageContext, LookupHookResult } from "../lib";
+import { PageContext, LookupHookResult } from "../runtime/page-types";
 
 /** Page hooks common to the server and client */
 export interface CommonHooks {

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -2,7 +2,7 @@ import { compose, RequestContext, RequestHandlerStack } from "@hattip/compose";
 import { ReactElement } from "react";
 import renderApiRoute from "../features/api-routes/middleware";
 import renderPageRoute from "../features/pages/middleware";
-import { PageContext } from "../lib";
+import { PageContext } from "../runtime/page-types";
 import serverHooks from "./feature-server-hooks";
 
 declare module "@hattip/compose" {

--- a/packages/rakkasjs/src/runtime/page-types.ts
+++ b/packages/rakkasjs/src/runtime/page-types.ts
@@ -1,11 +1,12 @@
-import { ComponentType, ReactNode } from "react";
-import { ResolvedConfig } from "vite";
-import {
-	PageContext,
+import type { ComponentType, ReactNode } from "react";
+import type { ResolvedConfig } from "vite";
+import type {
 	RedirectProps,
 	ResponseHeadersProps,
 	RequestContext,
 	HeadProps,
+	QueryClient,
+	PageLocals,
 } from "../lib";
 
 export type PageImporter = () => Promise<PageModule>;
@@ -214,4 +215,20 @@ export interface RouteConfig extends BaseRouteConfig {
 export interface BaseRouteConfig {
 	disabled?: boolean;
 	renderingMode?: "hydrate" | "server" | "client";
+}
+
+/** Context within which the page is being rendered */
+export interface PageContext {
+	/** URL */
+	url: URL;
+	/** Isomorphic fetch function */
+	fetch: typeof fetch;
+	/** Query client used by useQuery */
+	queryClient: QueryClient;
+	/** Request context, only defined on the server */
+	requestContext?: RequestContext;
+	/** Application-specific stuff */
+	locals: PageLocals;
+	/** Page action data */
+	actionData?: any;
 }

--- a/packages/rakkasjs/src/vite-plugin/index.ts
+++ b/packages/rakkasjs/src/vite-plugin/index.ts
@@ -129,12 +129,12 @@ const DEFAULT_NODE_ENTRY_CONTENTS = `
 `;
 
 const DEFAULT_HATTIP_ENTRY_CONTENTS = `
-	import { createRequestHandler } from "rakkasjs";
+	import { createRequestHandler } from "rakkasjs/server";
 	export default createRequestHandler();
 `;
 
 const DEFAULT_CLIENT_ENTRY_CONTENTS = `
-	import { startClient } from "rakkasjs";
+	import { startClient } from "rakkasjs/client";
 	startClient();
 `;
 

--- a/packages/rakkasjs/tsup.config.ts
+++ b/packages/rakkasjs/tsup.config.ts
@@ -49,7 +49,10 @@ export default defineConfig([
 		dts: true,
 	},
 	{
-		entry: ["./src/lib/client.ts"],
+		entry: {
+			"index.client": "./src/lib/index.client.ts",
+			client: "./src/runtime/client-entry.tsx",
+		},
 		target: "node18",
 		format: ["esm"],
 		platform: "node",
@@ -78,13 +81,19 @@ export default defineConfig([
 			"@microsoft/fetch-event-source",
 		],
 		dts: {
-			entry: "./src/lib/index.ts",
-			resolve: ["react-error-boundary"],
+			entry: {
+				index: "./src/lib/index.client.ts",
+				client: "./src/runtime/client-entry.tsx",
+				server: "./src/runtime/hattip-handler.ts",
+			},
 		},
 		plugins: [namedExports()],
 	},
 	{
-		entry: ["./src/lib/server.ts"],
+		entry: {
+			"index.server": "./src/lib/index.server.ts",
+			server: "./src/runtime/hattip-handler.ts",
+		},
 		format: ["esm"],
 		platform: "node",
 		shims: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -993,6 +993,9 @@ importers:
       vite:
         specifier: ^5.0.12
         version: 5.0.12(@types/node@20.11.5)
+      vite-plugin-inspect:
+        specifier: ^0.8.2
+        version: 0.8.2(vite@5.0.12)
       wrangler:
         specifier: ^3.23.0
         version: 3.23.0
@@ -1427,6 +1430,13 @@ packages:
     dependencies:
       "@jridgewell/gen-mapping": 0.3.3
       "@jridgewell/trace-mapping": 0.3.20
+
+  /@antfu/utils@0.7.7:
+    resolution:
+      {
+        integrity: sha512-gFPqTG7otEJ8uP6wrhDv6mqwGWYZKNvAcCq6u9hOj0c+IKCEsY4L1oC9trPq2SaWIzAfHvqfBDxF591JkMf+kg==,
+      }
+    dev: true
 
   /@auth/core@0.22.0:
     resolution:
@@ -8296,6 +8306,16 @@ packages:
       undici-types: 5.28.2
     dev: true
 
+  /bundle-name@4.1.0:
+    resolution:
+      {
+        integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==,
+      }
+    engines: { node: ">=18" }
+    dependencies:
+      run-applescript: 7.0.0
+    dev: true
+
   /bundle-require@4.0.2(esbuild@0.19.8):
     resolution:
       {
@@ -9712,6 +9732,25 @@ packages:
     engines: { node: ">=0.10.0" }
     dev: false
 
+  /default-browser-id@5.0.0:
+    resolution:
+      {
+        integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==,
+      }
+    engines: { node: ">=18" }
+    dev: true
+
+  /default-browser@5.2.1:
+    resolution:
+      {
+        integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==,
+      }
+    engines: { node: ">=18" }
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.0
+    dev: true
+
   /defaults@1.0.4:
     resolution:
       {
@@ -9747,6 +9786,14 @@ packages:
       }
     engines: { node: ">=8" }
     dev: false
+
+  /define-lazy-prop@3.0.0:
+    resolution:
+      {
+        integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==,
+      }
+    engines: { node: ">=12" }
+    dev: true
 
   /define-properties@1.2.1:
     resolution:
@@ -10324,6 +10371,13 @@ packages:
       }
     dependencies:
       is-arrayish: 0.2.1
+
+  /error-stack-parser-es@0.1.1:
+    resolution:
+      {
+        integrity: sha512-g/9rfnvnagiNf+DRMHEVGuGuIBlCIMDFoTA616HaP2l9PlCjGjVhD98PNbVSJvmK4TttqT5mV5tInMhoFgi+aA==,
+      }
+    dev: true
 
   /error-stack-parser@2.1.4:
     resolution:
@@ -11991,6 +12045,18 @@ packages:
       }
     dev: false
 
+  /fs-extra@11.2.0:
+    resolution:
+      {
+        integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==,
+      }
+    engines: { node: ">=14.14" }
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+    dev: true
+
   /fs-extra@8.1.0:
     resolution:
       {
@@ -13585,7 +13651,6 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     hasBin: true
-    dev: false
 
   /is-extendable@0.1.1:
     resolution:
@@ -13692,7 +13757,6 @@ packages:
     hasBin: true
     dependencies:
       is-docker: 3.0.0
-    dev: false
 
   /is-installed-globally@0.4.0:
     resolution:
@@ -14008,7 +14072,6 @@ packages:
     engines: { node: ">=16" }
     dependencies:
       is-inside-container: 1.0.0
-    dev: false
 
   /is-yarn-global@0.4.1:
     resolution:
@@ -14261,6 +14324,17 @@ packages:
       {
         integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==,
       }
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
+  /jsonfile@6.1.0:
+    resolution:
+      {
+        integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==,
+      }
+    dependencies:
+      universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
     dev: true
@@ -14597,7 +14671,6 @@ packages:
       {
         integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==,
       }
-    dev: false
 
   /lodash.defaults@4.2.0:
     resolution:
@@ -16922,6 +16995,19 @@ packages:
     dependencies:
       mimic-fn: 4.0.0
 
+  /open@10.0.3:
+    resolution:
+      {
+        integrity: sha512-dtbI5oW7987hwC9qjJTyABldTaa19SuyJse1QboWv3b0qCcrrLNVDqBx1XgELAjh9QTVQaP/C5b1nhQebd1H2A==,
+      }
+    engines: { node: ">=18" }
+    dependencies:
+      default-browser: 5.2.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      is-wsl: 3.1.0
+    dev: true
+
   /open@8.4.2:
     resolution:
       {
@@ -19056,6 +19142,14 @@ packages:
       "@rollup/rollup-win32-ia32-msvc": 4.9.6
       "@rollup/rollup-win32-x64-msvc": 4.9.6
       fsevents: 2.3.3
+
+  /run-applescript@7.0.0:
+    resolution:
+      {
+        integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==,
+      }
+    engines: { node: ">=18" }
+    dev: true
 
   /run-async@2.4.1:
     resolution:
@@ -21393,6 +21487,14 @@ packages:
     engines: { node: ">= 4.0.0" }
     dev: true
 
+  /universalify@2.0.1:
+    resolution:
+      {
+        integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
+      }
+    engines: { node: ">= 10.0.0" }
+    dev: true
+
   /unix-dgram@2.0.6:
     resolution:
       {
@@ -21829,6 +21931,34 @@ packages:
       estree-walker: 3.0.3
       magic-string: 0.30.5
       minimatch: 9.0.3
+    dev: true
+
+  /vite-plugin-inspect@0.8.2(vite@5.0.12):
+    resolution:
+      {
+        integrity: sha512-lMqPHkh1UNev0CwuO1g2naDfUanHRM7aorjx52SGrcVmAnhNxnbWzIuFNI3nCOXsSiOUeff4ZJSmR9tMAyMaSg==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@nuxt/kit": "*"
+      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0
+    peerDependenciesMeta:
+      "@nuxt/kit":
+        optional: true
+    dependencies:
+      "@antfu/utils": 0.7.7
+      "@rollup/pluginutils": 5.1.0
+      debug: 4.3.4(supports-color@9.4.0)
+      error-stack-parser-es: 0.1.1
+      fs-extra: 11.2.0
+      lodash-es: 4.17.21
+      open: 10.0.3
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vite: 5.0.12(@types/node@20.11.5)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
     dev: true
 
   /vite-tsconfig-paths@4.3.1(typescript@5.3.3)(vite@5.0.12):

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -337,18 +337,17 @@ function testCase(
 					await fs.promises.writeFile(filePath, newContent);
 
 					try {
-						await page.waitForFunction(() =>
-							document.body?.textContent?.includes("Hot reloadin'!"),
-						);
 						await page.waitForFunction(
 							() =>
+								document.body?.textContent?.includes("Hot reloadin'!") &&
 								document.querySelector("button")?.textContent === "Clicked: 1",
+							{ timeout: 15_000 },
 						);
 					} finally {
 						await fs.promises.writeFile(filePath, oldContent);
 					}
 				},
-				{ retry: 3, timeout: 15_000 },
+				{ retry: 3, timeout: 20_000 },
 			);
 
 			test(

--- a/testbed/kitchen-sink/package.json
+++ b/testbed/kitchen-sink/package.json
@@ -36,6 +36,7 @@
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",
+    "vite-plugin-inspect": "^0.8.2",
     "wrangler": "^3.23.0"
   },
   "dependencies": {

--- a/testbed/kitchen-sink/src/entry-hattip.ts
+++ b/testbed/kitchen-sink/src/entry-hattip.ts
@@ -1,3 +1,3 @@
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 
 export default createRequestHandler();

--- a/testbed/kitchen-sink/src/routes/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/index.page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Page } from "rakkasjs";
+import { Page, Link } from "rakkasjs";
 
 const HomePage: Page<never, { key: number }> = (props) => {
 	const [count, setCount] = useState(0);
@@ -9,9 +9,14 @@ const HomePage: Page<never, { key: number }> = (props) => {
 			<h1>Home</h1>
 			<p>Hello world!</p>
 			<p id="metadata">Metadata: {props.meta.key}</p>
-			<button onClick={() => setCount((old) => old + 1)}>
-				Clicked: {count}
-			</button>
+			<p>
+				<button onClick={() => setCount((old) => old + 1)}>
+					Clicked: {count}
+				</button>
+			</p>
+			<p>
+				<Link href="/">Just a link</Link>
+			</p>
 			{import.meta.env.DEV && <p>Development mode is active.</p>}
 		</>
 	);

--- a/testbed/kitchen-sink/vite.config.ts
+++ b/testbed/kitchen-sink/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import inspect from "vite-plugin-inspect";
 import react from "@vitejs/plugin-react";
 import reactSwc from "@vitejs/plugin-react-swc";
 import rakkas from "rakkasjs/vite-plugin";
@@ -8,6 +9,7 @@ export default defineConfig({
 		host: "127.0.0.1",
 	},
 	plugins: [
+		inspect(),
 		process.env.USE_SWC ? reactSwc() : react(),
 		rakkas({
 			adapter: (process.env.RAKKAS_TARGET as any) || "node",

--- a/website/src/routes/_site/guide/client-entry.page.mdx
+++ b/website/src/routes/_site/guide/client-entry.page.mdx
@@ -2,10 +2,10 @@
 title: Client entry
 ---
 
-The main client-side entry point of a Rakkas application is the `src/entry-client.js` (or `.ts`, `.jsx`, `.tsx`) file. Rakkas has a default implementation, so you don't have to provide one. But it exposes advanced customization features that you might find useful. If provided, it should call the `startClient` function to start the client.
+The main client-side entry point of a Rakkas application is the `src/entry-client.js` (or `.ts`, `.jsx`, `.tsx`) file. Rakkas has a default implementation, so you don't have to provide one. But it exposes advanced customization features that you might find useful. If provided, it should call the `startClient` function from the `rakkasjs/client` module to start the client.
 
 ```tsx
-import { startClient } from "rakkasjs";
+import { startClient } from "rakkasjs/client";
 
 startClient({
   hooks: {

--- a/website/src/routes/_site/guide/hattip-entry.page.mdx
+++ b/website/src/routes/_site/guide/hattip-entry.page.mdx
@@ -11,7 +11,7 @@ One important use case is injecting HatTip middleware into your application. Cur
 - [`@hattip/graphql`](https://github.com/hattipjs/hattip/blob/main/packages/middleware/graphql): GraphQL middleware
 
 ```tsx
-import { createRequestHandler } from "rakkasjs";
+import { createRequestHandler } from "rakkasjs/server";
 import { cookie } from "@hattip/cookie";
 
 export default createRequestHandler({


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE**

This PR fixes issue #192 (circular imports causing HMR failures). It required some reorganization:

- `startClient` used in `entry-client` is now exported from `rakkasjs/client`.
- `createRequestHandler` used in `entry-hattip` is now exported from `rakkasjs/server`.

I always already planning to do this for other reasons so it's perfectly OK.
