### PR TITLE
feat: implement page-urls command (preliminary)

### DIFF
--- a/packages/rakkasjs/package.json
+++ b/packages/rakkasjs/package.json
@@ -58,7 +58,13 @@
   "peerDependencies": {
     "react": "18",
     "react-dom": "18",
+    "typescript": "5",
     "vite": "5"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@brillout/json-serializer": "^0.5.8",

--- a/packages/rakkasjs/src/cli/index.ts
+++ b/packages/rakkasjs/src/cli/index.ts
@@ -179,6 +179,19 @@ cli
 		import("./prerender").then(({ prerender }) => prerender(paths, options)),
 	);
 
+cli
+	.command("page-urls", "Generate a URL builder for pages")
+	.option(
+		"-s, --search <search-param-serializer-module[::export-name]>",
+		"Module name that default exports a search param serializer. E.g. qs::stringify.",
+	)
+	.action((options: { search?: string }) =>
+		import("./page-urls").then(
+			({ generatePageUrlBuilder: generateUrlBuilder }) =>
+				generateUrlBuilder(options),
+		),
+	);
+
 cli.help();
 cli.version(version);
 

--- a/packages/rakkasjs/src/cli/page-urls.ts
+++ b/packages/rakkasjs/src/cli/page-urls.ts
@@ -1,0 +1,250 @@
+/* eslint-disable import/no-named-as-default-member */
+// eslint-disable-next-line import/no-named-as-default
+import glob from "fast-glob";
+import ts from "typescript";
+import { normalizePathSegment } from "../internal/route-utils";
+import { writeFileSync } from "node:fs";
+
+export async function generatePageUrlBuilder({
+	search: searchModule,
+}: { search?: string } = {}) {
+	const pageModules = (
+		await glob("**/*.page.tsx", {
+			cwd: "src/routes",
+		})
+	).filter((m) => !m.endsWith("$404.page.tsx"));
+
+	const parsedConfig = ts.readConfigFile("tsconfig.json", ts.sys.readFile);
+
+	if (parsedConfig.error) {
+		console.error(parsedConfig.error);
+		throw new Error("Failed to parse tsconfig.json");
+	}
+
+	const config = ts.parseJsonConfigFileContent(
+		parsedConfig.config,
+		ts.sys,
+		"./",
+	);
+
+	const program = ts.createProgram({
+		rootNames: pageModules.map((m) => "src/routes/" + m),
+		options: config.options,
+	});
+
+	const names = new Map<
+		string,
+		{
+			path: string;
+			search?: string;
+			hash?: string;
+		}
+	>();
+
+	for (const path of pageModules) {
+		const sf = program.getSourceFile("src/routes/" + path);
+
+		const checker = program.getTypeChecker();
+		const sourceFileSymbol = checker.getSymbolAtLocation(sf!)!;
+		const exports = checker.getExportsOfModule(sourceFileSymbol);
+
+		// Get default export's local name
+		const defaultExport = exports.find((e) => e.escapedName === "default");
+
+		const firstDecl = defaultExport?.declarations?.[0] as any;
+		let defaultExportName =
+			firstDecl?.propertyName?.escapedText ??
+			firstDecl?.name?.escapedText ??
+			firstDecl?.expression?.escapedText;
+
+		if (!defaultExportName || defaultExportName === "default") {
+			console.warn(`No default export name found in ${path}`);
+			continue;
+		}
+
+		const search = (
+			exports.find((e) => e.escapedName === defaultExportName + "Search")
+				?.declarations?.[0] as any
+		)?.name?.escapedText;
+
+		const hash = (
+			exports.find((e) => e.escapedName === defaultExportName + "Hash")
+				?.declarations?.[0] as any
+		)?.name?.escapedText;
+
+		if (defaultExportName.endsWith("Page")) {
+			defaultExportName = defaultExportName.slice(0, -4);
+		}
+
+		defaultExportName =
+			defaultExportName[0].toLowerCase() + defaultExportName.slice(1);
+
+		if (names.has(defaultExportName)) {
+			console.warn(
+				`Duplicate default export name "${defaultExportName}" found in "${path}" (previously used in "${names.get(defaultExportName)}").`,
+			);
+		}
+
+		names.set(defaultExportName, {
+			path,
+			search,
+			hash,
+		});
+	}
+
+	// Disable ESLint for the output
+	let output = `/* eslint-disable */\n`;
+
+	if ([...names.values()].some((n) => n.search)) {
+		if (searchModule) {
+			const [module, symbol] = searchModule.split("::");
+			if (!symbol) {
+				output += `import _s from ${JSON.stringify(module)};\n`;
+			} else {
+				output += `import { ${symbol} as _s } from ${JSON.stringify(module)};\n`;
+			}
+		}
+	}
+
+	for (const [, { path, search, hash }] of names) {
+		if (!search && !hash) {
+			continue;
+		}
+
+		output += "import type { ";
+
+		output += [search, hash].filter(Boolean).join(", ");
+
+		output += ` } from ${JSON.stringify("./routes/" + path.slice(0, -4))};\n`;
+	}
+
+	if (output) {
+		output += "\n";
+	}
+
+	output += `export const pages = {`;
+
+	for (const [name, { path: pm, search, hash }] of names) {
+		const params = new Set<string>();
+		let catchAllParam: string | undefined;
+
+		const path =
+			"/" +
+			pm
+				.slice(0, -9)
+				.split("/")
+				.filter((segment) => segment !== "index" && !segment.startsWith("_"))
+				.map((segment) =>
+					/* Split subsegments. E.g. hello-[name]-[surname] => hello-, [name], -, [surname]*/ segment
+						.split(/(?=\[)|(?<=\])/g)
+						.map((sub) => {
+							if (sub.startsWith("[")) {
+								let param = sub.slice(1, -1);
+								if (param.startsWith("...")) {
+									param = param.slice(3);
+									catchAllParam = param;
+									params.add(param);
+									return "";
+								} else {
+									params.add(param);
+									return "${" + param + "}";
+								}
+							}
+
+							return normalizePathSegment(sub);
+						})
+						.join(""),
+				)
+				.filter(Boolean)
+				.join("/");
+
+		let arg = "";
+		output += `\n\t${name}: `;
+		let line: string;
+		let decons = "";
+		let type = "never";
+		if (params.size || search || hash) {
+			decons = params.size ? "{ " + [...params].join(", ") + " }" : "_params";
+			type = "{ " + [...params].map((p) => p + ": string").join(", ") + " }";
+			if (!params.size) {
+				type += ` | undefined`;
+			}
+
+			if (search) {
+				type += `, search: ${search}`;
+			}
+
+			if (hash) {
+				type += `, hash: ${hash}`;
+			}
+
+			arg = `${decons}: ${type}`;
+
+			if (catchAllParam) {
+				line = `(${arg}) => _u\`${path}\` + ${catchAllParam}`;
+			} else {
+				line = `(${arg}) => _u\`${path}\``;
+			}
+		} else {
+			line = `() => ${JSON.stringify(path)}`;
+		}
+
+		output += line;
+
+		if (search) {
+			output += ` + _q(search)`;
+		}
+
+		if (hash) {
+			output += ` + _h(hash)`;
+		}
+
+		output += ",";
+	}
+
+	const union = [...names.values()]
+		.filter((n) => n.search)
+		.map((n) => n.search)
+		.join(" | ");
+
+	output += "\n};\n";
+
+	output += "\ntype _SearchUnion = " + (union || "any") + ";\n";
+
+	output += UTILS_SRC;
+
+	if (!searchModule) {
+		output += SEARCH_SRC;
+	}
+
+	writeFileSync("src/page-urls.ts", output);
+}
+
+const UTILS_SRC = `
+function _u(parts: TemplateStringsArray, ...args: string[]): string {
+	let result = "";
+	for (let i = 0; i < parts.length; i++) {
+		result += parts[i];
+		if (i < args.length) {
+			result += encodeURIComponent(args[i]);
+		}
+	}
+
+	return result;
+}
+
+function _q(search: _SearchUnion): string {
+	const result = _s(search);
+	return result ? "?" + result : "";
+}
+
+function _h(hash: any): string {
+	return hash ? "#" + hash : "";
+}
+`;
+
+const SEARCH_SRC = `
+function _s(search: _SearchUnion): string {
+	return new URLSearchParams(search).toString();
+}
+`;

--- a/testbed/kitchen-sink/src/routes/env.page.tsx
+++ b/testbed/kitchen-sink/src/routes/env.page.tsx
@@ -9,3 +9,9 @@ export default function EnvPage() {
 
 	return <pre>{JSON.stringify(data, null, 2)}</pre>;
 }
+
+export type EnvPageSearch = {
+	foo: string;
+};
+
+export type EnvPageHash = "bar" | "baz";


### PR DESCRIPTION
This PR implements a new CLI command `rakkas page-urls` that generates a URL builder for creating page URLs in a type-safe manner. Currently it is very simple and brittle but I think it's pretty useful already so it's worth releasing.

**Note that you don't have to upgrade right away to use this feature.** You can simply run it with `npx rakkasjs@next page-urls` (or `pnpm dlx rakkasjs@next page-urls` etc.) in your project root. Just make sure you don't have anything important in `src/page-urls.ts` because it will be overwritten.

## Usage

If you run the `rakkas page-urls` command in your project root, where `tsconfig.json` is located and `src/routes/**/*.page.tsx` are your page files, it will generate a file called `src/page-urls.ts`. It will contain a `pages` export that is a map of page names to functions that take the page's parameters and return the URL for that page. For example, if you have a page module called `src/routes/blog/[slug].page.tsx` that exports a `BlogPostPage` page component, you can build the URL with `pages.blogPost({ slug: 'hello-world' })`.

The page names (e.g. `blogPost`) are derived from the export names. If the export name ends with `Page`, that part is removed. If the export name cannot be determined or is duplicate, the command will print a warning and skip that page.

The generated module is also capable of serializing search parameters and hash fragments. For that to work, you need to export a `BlogPostPageSearch` and/or `BlogPostPageHash` type from your page module where `BlogPostPage` is the default export. For example, if you export the following from your blog post list page:

```ts
export default function BlogPostListPage() {
  // ...
}

// Export a type, not an interface!
export type BlogPostListPageSearch =
  | {
      author?: string;
      tag?: string;
    }
  | undefined; // Make it optional

export type BlogPostListPageHash = "top" | "new" | undefined;
```

you will be able to build a URL in a type-safe manner like this:

```ts
pages.blogPostList({}, { author: "john", tag: "typescript" }, "top");
```

and it will produce something like `/blog?author=john&tag=typescript#top`.

The hash part is simply converted to a string while the the search part is serialized using `new URLSearchParams(search).toString()`. You can override the search param serializer with the `-s` (or `--search`) CLI option. For example, if you want to use `stringify` from the `qs` package, you can run `rakkas page-urls -s qs::stringify`. The `::` works as a separator between the module name and the function name. If you omit the module name, it will default to `querystring` (built-in Node.js module). If you omit the function name, the default export of the module will be used. You can use local modules as well, e.g. `rakkas page-urls -s ./my-serializer::serialize`.

## Type-safe links

A type-safe link component can be implemented on top of the generated module. Here's an example (quick and dirty, not well tested!):

```tsx
import { Link, LinkProps } from "rakkasjs";
import { pages } from "./page-urls";

type Pages = typeof pages;

export type SafeLinkProps<N extends keyof Pages> = Omit<LinkProps, "href"> & {
  to: {
    name: N;
  } & (Parameters<Pages[N]>[0] extends undefined
    ? {}
    : {
        params: Parameters<Pages[N]>[0];
      }) &
    (Parameters<Pages[N]>[1] extends undefined
      ? {}
      : {
          search: Parameters<Pages[N]>[1];
        }) &
    (Parameters<Pages[N]>[2] extends undefined
      ? {}
      : {
          hash: Parameters<Pages[N]>[2];
        });
};

export function SafeLink<N extends keyof Pages>({
  to,
  ...props
}: SafeLinkProps<N>) {
  return (
    <Link
      {...props}
      href={(pages[to.name] as any)(
        (to as any).params,
        (to as any).search,
        (to as any).hash,
      )}
    />
  );
}`
```

It can be used like this:

```tsx
<SafeLink
  to={{
    name: "blogPost",
    params: { slug: "hello-world" },
    search: { author: "john" },
    hash: "top",
  }}
>
  Read more
</SafeLink>
```

## Caveats

- `tsconfig.json` must be in the current working directory and pages must be in `src/routes/**/*.page.tsx` relative to it.
- Only `*.page.tsx` files are processed. Other extensions like `*.page.jsx` or `*.page.mdx` are not yet supported.
- The parser uses TypeScript's compiler API but it's not error-tolerant and it doesn't cover all edge cases. Report any issues you find.
- The generated module is not updated automatically when you add, remove, or update pages. You need to run the command again to update it.
- API routes are not yet supported.

## Future plans

This feature could have been implemented as an external tool but having it in the core opens up some possibilities for the future when type-safe routing and config-based routing are implemented.
