### PR TITLE
feat: second iteration on URL builder

### DIFF
--- a/packages/rakkasjs/src/cli/page-urls.ts
+++ b/packages/rakkasjs/src/cli/page-urls.ts
@@ -41,6 +41,8 @@ export async function generatePageUrlBuilder({
 		}
 	>();
 
+	let hasSearch = false;
+
 	for (const path of pageModules) {
 		const sf = program.getSourceFile("src/routes/" + path);
 
@@ -66,6 +68,10 @@ export async function generatePageUrlBuilder({
 			exports.find((e) => e.escapedName === defaultExportName + "Search")
 				?.declarations?.[0] as any
 		)?.name?.escapedText;
+
+		if (search) {
+			hasSearch = true;
+		}
 
 		const hash = (
 			exports.find((e) => e.escapedName === defaultExportName + "Hash")
@@ -93,9 +99,10 @@ export async function generatePageUrlBuilder({
 	}
 
 	// Disable ESLint for the output
-	let output = `/* eslint-disable */\n`;
+	let output =
+		`/* eslint-disable */\n` + `// This file is generated automatically\n\n`;
 
-	if ([...names.values()].some((n) => n.search)) {
+	if (hasSearch) {
 		if (searchModule) {
 			const [module, symbol] = searchModule.split("::");
 			if (!symbol) {
@@ -124,6 +131,9 @@ export async function generatePageUrlBuilder({
 
 	output += `export const pages = {`;
 
+	let urlEscapeUsed = false;
+	let hashSerializerUsed = false;
+
 	for (const [name, { path: pm, search, hash }] of names) {
 		const params = new Set<string>();
 		let catchAllParam: string | undefined;
@@ -131,6 +141,7 @@ export async function generatePageUrlBuilder({
 		const path =
 			"/" +
 			pm
+				.replace(/\\|--/g, "/")
 				.slice(0, -9)
 				.split("/")
 				.filter((segment) => segment !== "index" && !segment.startsWith("_"))
@@ -164,63 +175,83 @@ export async function generatePageUrlBuilder({
 		let decons = "";
 		let type = "never";
 		if (params.size || search || hash) {
-			decons = params.size ? "{ " + [...params].join(", ") + " }" : "_params";
-			type = "{ " + [...params].map((p) => p + ": string").join(", ") + " }";
-			if (!params.size) {
-				type += ` | undefined`;
-			}
-
-			if (search) {
-				type += `, search: ${search}`;
-			}
+			const deconsBits = [...params];
+			type = "{ " + [...params].map((p) => p + ": string").join(", ");
 
 			if (hash) {
-				type += `, hash: ${hash}`;
+				deconsBits.push("hash");
+				if (params.size) type += ", ";
+				type += `hash: ${hash}`;
 			}
+
+			type += " }";
+
+			if (search) {
+				deconsBits.push("..._search");
+				type += ` & ${search}`;
+			}
+
+			decons = `{ ${deconsBits.join(", ")} }`;
 
 			arg = `${decons}: ${type}`;
 
-			if (catchAllParam) {
-				line = `(${arg}) => _u\`${path}\` + ${catchAllParam}`;
+			if (params.size) {
+				if (catchAllParam) {
+					line = `(${arg}) => _u\`${path}\` + ${catchAllParam}`;
+				} else {
+					line = `(${arg}) => _u\`${path}\``;
+				}
+
+				urlEscapeUsed = true;
 			} else {
-				line = `(${arg}) => _u\`${path}\``;
+				line = `(${arg}) => ${JSON.stringify(path)}`;
 			}
 		} else {
-			line = `() => ${JSON.stringify(path)}`;
+			line = `(${arg}) => ${JSON.stringify(path)}`;
 		}
 
 		output += line;
 
 		if (search) {
-			output += ` + _q(search)`;
+			output += ` + _q(_search)`;
 		}
 
 		if (hash) {
 			output += ` + _h(hash)`;
+			hashSerializerUsed = true;
 		}
 
 		output += ",";
 	}
 
-	const union = [...names.values()]
-		.filter((n) => n.search)
-		.map((n) => n.search)
-		.join(" | ");
-
 	output += "\n};\n";
 
-	output += "\ntype _SearchUnion = " + (union || "any") + ";\n";
+	if (urlEscapeUsed) {
+		output += URL_ESCAPE_SRC;
+	}
 
-	output += UTILS_SRC;
+	if (hasSearch) {
+		const union = [...names.values()]
+			.filter((n) => n.search)
+			.map((n) => n.search)
+			.join(" | ");
+		output += "\ntype _SearchUnion = " + (union || "any") + ";\n";
 
-	if (!searchModule) {
-		output += SEARCH_SRC;
+		if (!searchModule) {
+			output += SEARCH_SERIALIZER_SRC;
+		}
+
+		output += SEARCH_WRAPPER_SRC;
+	}
+
+	if (hashSerializerUsed) {
+		output += HASH_SERIALIZER_SRC;
 	}
 
 	writeFileSync("src/page-urls.ts", output);
 }
 
-const UTILS_SRC = `
+const URL_ESCAPE_SRC = `
 function _u(parts: TemplateStringsArray, ...args: string[]): string {
 	let result = "";
 	for (let i = 0; i < parts.length; i++) {
@@ -232,18 +263,22 @@ function _u(parts: TemplateStringsArray, ...args: string[]): string {
 
 	return result;
 }
+`;
 
+const SEARCH_WRAPPER_SRC = `
 function _q(search: _SearchUnion): string {
 	const result = _s(search);
 	return result ? "?" + result : "";
 }
+`;
 
+const HASH_SERIALIZER_SRC = `
 function _h(hash: any): string {
 	return hash ? "#" + hash : "";
 }
 `;
 
-const SEARCH_SRC = `
+const SEARCH_SERIALIZER_SRC = `
 function _s(search: _SearchUnion): string {
 	return new URLSearchParams(search).toString();
 }


### PR DESCRIPTION
This is the second iteration of the URL builder. The [previous design](https://github.com/rakkasjs/rakkasjs/pull/200) proved to be too cumbersome to use in real life. This PR merges path parameters, search parameters, and the hash into a single argument. So the following code:

```ts
pages.blogPostList({}, { author: "john", tag: "typescript" }, "top");
```

is now simplified to:

```ts
pages.blogPostList({ author: "john", tag: "typescript", hash: "top" });
```

In other words, there is now a single shared namespace for the path params, search params, and the hash. The parameter name `hash` is reserved for the URL hash when it's used. Despite being less flexible, it is much easier to work with.

And here's a better implementation of a type-safe link:

```tsx
import { StyledLink, StyledLinkProps } from "rakkasjs";
import { pages } from "./page-urls";

// This can be used to globally narrow down param types.
// For example, in this app, all `lang` params, whether it's
// a path param or a search param, is of type "en" | "tr" | "ar".
// An empty interface will disable global type narrowing.
interface ParamTypes {
  lang: "en" | "tr" | "ar";
}

type Pages = typeof pages;

type Typed<T> = {
  [key in keyof T]: key extends keyof ParamTypes ? ParamTypes[key] : T[key];
};

export type AppLinkProps<N extends keyof Pages> = Omit<
  StyledLinkProps,
  "href"
> &
  Parameters<Pages[N]>[0] extends undefined
  ? {
      to: N;
      params?: Record<string, never>;
    }
  : {
      to: N;
      params: Typed<Parameters<Pages[N]>[0]>;
    };

export function AppLink<N extends keyof Pages>({
  to,
  params,
  ...props
}: AppLinkProps<N>) {
  return <StyledLink {...props} href={(pages[to] as any)(params)} />;
}
```

It can be used like this:

```tsx
<AppLink to="dashboard" params={{ lang: "tr", foo: "bar" }} />
<AppLink to="static" /> // params can be omitted when it's allowed to be empty for that route
```

Both `to` and `params` are strongly typed, including the `lang` param.