### PR TITLE
feat: link preloading

### DIFF
--- a/packages/rakkasjs/src/features/client-side-navigation/implementation.tsx
+++ b/packages/rakkasjs/src/features/client-side-navigation/implementation.tsx
@@ -332,6 +332,10 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 	 * @default "hover"
 	 */
 	prefetch?: "eager" | "viewport" | "idle" | "hover" | "tap" | "never";
+	/**
+	 * Whether to preload the data for the new page. This is only effective when `prefetch` is enabled.
+	 */
+	preload?: boolean;
 }
 
 /** Link component for client-side navigation */
@@ -348,6 +352,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 			onTouchStart,
 			onMouseDown,
 			prefetch = "hover",
+			preload = false,
 			...props
 		},
 		ref,
@@ -362,13 +367,13 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 			if (props.href === undefined) {
 				return;
 			} else if (prefetch === "eager") {
-				prefetchRoute(props.href);
+				prefetchRoute(props.href, preload);
 			} else if (prefetch === "viewport" && inView) {
-				prefetchRoute(props.href);
+				prefetchRoute(props.href, preload);
 			} else if (prefetch === "idle" && inView) {
-				requestIdleCallback(() => prefetchRoute(props.href!));
+				requestIdleCallback(() => prefetchRoute(props.href!, preload));
 			}
-		}, [props.href, prefetch, a, inView]);
+		}, [props.href, prefetch, a, inView, preload]);
 
 		return (
 			<a
@@ -408,7 +413,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 						? (e) => {
 								onMouseEnter?.(e);
 								if (!e.defaultPrevented) {
-									prefetchRoute(e.currentTarget.href);
+									prefetchRoute(e.currentTarget.href, preload);
 								}
 							}
 						: onMouseEnter
@@ -418,7 +423,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 						? (e) => {
 								onMouseDown?.(e);
 								if (!e.defaultPrevented) {
-									prefetchRoute(e.currentTarget.href);
+									prefetchRoute(e.currentTarget.href, preload);
 								}
 							}
 						: onMouseDown
@@ -428,7 +433,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 						? (e) => {
 								onTouchStart?.(e);
 								if (!e.defaultPrevented) {
-									prefetchRoute(e.currentTarget.href);
+									prefetchRoute(e.currentTarget.href, preload);
 								}
 							}
 						: onTouchStart
@@ -662,16 +667,19 @@ function ignore() {
 
 export const prefetcher = {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	prefetch(location: URL | string) {
+	prefetch(location: URL | string, preload: boolean) {
 		// Do nothing until initialized
 	},
 };
 
 /**
  * Preload a page's code and possibly data.
+ *
+ * @param location URL of the page to preload
+ * @param preload Whether to also preload the data
  */
-export function prefetchRoute(location: URL | string) {
-	prefetcher.prefetch(location);
+export function prefetchRoute(location: URL | string, preload = false) {
+	prefetcher.prefetch(location, preload);
 }
 
 function useInView<T extends HTMLElement>() {

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -62,7 +62,7 @@ export function App(props: AppProps) {
 	pageContext.actionData = actionData;
 
 	if (!import.meta.env.SSR) {
-		prefetcher.prefetch = function prefetch(location) {
+		prefetcher.prefetch = function prefetch(location, preload) {
 			const url = new URL(location, currentUrl);
 			url.hash = "";
 
@@ -77,7 +77,7 @@ export function App(props: AppProps) {
 				props.ssrMeta,
 				props.ssrPreloaded,
 				props.ssrModules,
-				true,
+				preload ? "preload" : true,
 			).catch((e) => {
 				console.error(e);
 			});
@@ -156,7 +156,7 @@ export async function loadRoute(
 	ssrMeta?: any,
 	ssrPreloaded?: (void | PreloadResult<Record<string, unknown>>)[],
 	ssrModules?: (PageModule | LayoutModule)[],
-	prefetchOnly = false,
+	prefetchOnly: boolean | "preload" = false,
 ) {
 	let found = lastFound;
 	const { pathname: originalPathname } = url;
@@ -300,7 +300,7 @@ export async function loadRoute(
 	const promises = importers.map(async (importer, i) =>
 		Promise.resolve(ssrModules?.[importers.length - 1 - i] || importer()).then(
 			async (module) => {
-				if (prefetchOnly) return;
+				if (prefetchOnly === true) return;
 
 				const preload =
 					import.meta.hot && updatedComponents

--- a/testbed/kitchen-sink/src/routes/query-options/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/query-options/index.page.tsx
@@ -28,6 +28,6 @@ function doubler(x: number) {
 				return x * 2;
 			});
 		},
-		staleTime: 1000,
+		staleTime: 15_000,
 	});
 }


### PR DESCRIPTION
This PR implements link preloading. [Link prefetching](https://github.com/rakkasjs/rakkasjs/pull/157) as previously implemented only fetches JavaScript and CSS assets for the next page. Preloading allows you to run the `preload` function as well, making the data ready for the next navigation.

It is enabled by passing a `preload` prop to the `Link` component or by passing `true` for the second argument of the `prefetchRoute` function for programmatic use. The `preload` prop can take the same values as the `prefetch` prop but it can also be set to `true` to preload when prefetching.

In Rakkas, the `preload` functions live in the page/layout modules so it's not possible to preload without also prefetching. So, if the `preload` setting is more eager than the `prefetch` setting, Rakkas will act as if `prefetch` was set to the same value as `preload`.

For this to bring any performance benefit, you should increase the `staleTime` of the queries that you prefetch in your `preload` function from the default of 100 ms. Otherwise they risk becoming stale by the time user actually navigates to the target page, causing preload effort to go to waste. In the following example, the preloaded data will be available for five seconds.

```ts
const MyPage: Page = ...

export default MyPage;

MyPage.preload = (ctx) => {
  ctx.prefetchQuery(myQuery);
};

const myQuery = queryOptions({
  queryKey: "myQuery",
  async queryFn(ctx) {
    // Do the actual fetching here
  }
  staleTime: 5000,
});
```
