### PR TITLE
feat: better head tag ordering

### DIFF
--- a/packages/rakkasjs/src/features/client-side-navigation/implementation.tsx
+++ b/packages/rakkasjs/src/features/client-side-navigation/implementation.tsx
@@ -294,7 +294,7 @@ function handleNavigation(e: unknown) {
 
 	startTransition(() => {
 		locationChangeListeners.forEach((listener) => listener());
-		(window as any).$RAKKAS_UPDATE?.();
+		rakkas.update?.();
 	});
 }
 

--- a/packages/rakkasjs/src/features/head/implementation/Head.tsx
+++ b/packages/rakkasjs/src/features/head/implementation/Head.tsx
@@ -84,14 +84,24 @@ function updateHead() {
 	);
 
 	const currentElements: HTMLElement[] = [];
+
 	let endNode: Node | null = null;
+	let started = false;
 	for (const node of document.head.childNodes) {
-		if (
-			node.nodeType === Node.COMMENT_NODE &&
-			node.nodeValue === " head end "
-		) {
-			endNode = node;
-			break;
+		if (node.nodeType === Node.COMMENT_NODE) {
+			if (node.nodeValue === " head start ") {
+				started = true;
+				continue;
+			}
+
+			if (node.nodeValue === " head end ") {
+				endNode = node;
+				break;
+			}
+		}
+
+		if (!started) {
+			continue;
 		}
 
 		if (node.nodeType === Node.ELEMENT_NODE) {
@@ -104,6 +114,10 @@ function updateHead() {
 	while (iNew < newElements.length || iCur < currentElements.length) {
 		const newElement = newElements[iNew];
 		let currentElement = currentElements[iCur];
+
+		if (currentElement?.hasAttribute("data:sr")) {
+			continue;
+		}
 
 		if (!newElement) {
 			do {

--- a/packages/rakkasjs/src/features/head/implementation/defaults.ts
+++ b/packages/rakkasjs/src/features/head/implementation/defaults.ts
@@ -6,3 +6,5 @@ export const defaultHeadProps: HeadProps = {
 	htmlAttributes: { lang: "en" },
 	elements: [{ charset: "utf-8" }],
 };
+
+export const currentDefaultHeadProps = { current: defaultHeadProps };

--- a/packages/rakkasjs/src/features/head/implementation/sort.ts
+++ b/packages/rakkasjs/src/features/head/implementation/sort.ts
@@ -41,7 +41,7 @@ export function sortHeadTags(tags: NormalizedHeadProps): Array<Attributes> {
 			case "link":
 				if (tag.rel === "preconnect") return 5;
 				if (tag.rel === "stylesheet") return 11;
-				if (tag.rel === "preload") return 12;
+				if (tag.rel === "preload" || tag.rel === "modulepreload") return 12;
 				if (tag.rel === "prefetch" || tag.rel === "prerender") return 15;
 				return 16;
 

--- a/packages/rakkasjs/src/features/head/implementation/types.ts
+++ b/packages/rakkasjs/src/features/head/implementation/types.ts
@@ -168,7 +168,7 @@ export interface OtherLinkTag extends CommonLinkAttributes {
 
 export interface CommonLinkAttributes extends CommonAttributes {
 	blocking?: boolean;
-	crossorigin?: "anonymous" | "use-credentials" | false;
+	crossorigin?: "anonymous" | "use-credentials" | boolean;
 	fetchpriority?: "auto" | "high" | "low" | false;
 	href: string;
 	hreflang?: string | false;
@@ -256,7 +256,6 @@ export interface CommonAttributes {
 	autofocus?: boolean;
 	class?: string | false;
 	contenteditable?: boolean;
-	["data-*"]?: string | false;
 	dir?: "ltr" | "rtl" | "auto" | (string & {}) | false;
 	draggable?: boolean;
 	enterkeyhint?:
@@ -303,4 +302,5 @@ export interface CommonAttributes {
 	virtualkeyboardpolicy?: "auto" | "manual" | (string & {}) | false;
 	"xml:lang"?: string | false;
 	"xmlns:base"?: string | false;
+	[key: `data-${string}`]: string | boolean;
 }

--- a/packages/rakkasjs/src/features/pages/vite-plugin.ts
+++ b/packages/rakkasjs/src/features/pages/vite-plugin.ts
@@ -357,7 +357,7 @@ export default function pageRoutes(options: PageRoutesOptions = {}): Plugin[] {
 const PAGE_HOT_RELOAD = `
 	if (import.meta.hot) {
 		import.meta.hot.accept(() => {
-			$RAKKAS_UPDATE?.();
+			rakkas.update();
 		});
 	}
 `;

--- a/packages/rakkasjs/src/features/use-query/client-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/client-hooks.tsx
@@ -18,9 +18,6 @@ export default defineClientHooks({
 	},
 });
 
-// Rakkas Suspense Cache
-declare const $RSC: Record<string, any> | undefined;
-
 const queryCache: Record<string, CacheItem | undefined> = Object.create(null);
 
 export function resetErrors() {
@@ -59,20 +56,20 @@ const cache: QueryCache = {
 	},
 
 	has(key: string) {
-		return key in queryCache || (typeof $RSC !== "undefined" && key in $RSC);
+		return key in queryCache || (!!rakkas.cache && key in rakkas.cache);
 	},
 
 	get(key: string) {
-		if (!queryCache[key] && typeof $RSC !== "undefined" && key in $RSC) {
+		if (!queryCache[key] && rakkas.cache && key in rakkas.cache) {
 			queryCache[key] = {
-				value: $RSC[key],
+				value: rakkas.cache[key],
 				subscribers: new Set(),
 				date: Date.now(),
 				hydrated: true,
 				cacheTime: DEFAULT_QUERY_OPTIONS.cacheTime,
 			};
 
-			delete $RSC[key];
+			delete rakkas.cache[key];
 		}
 
 		return queryCache[key];

--- a/packages/rakkasjs/src/features/use-query/server-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/server-hooks.tsx
@@ -94,15 +94,15 @@ const useQueryServerHooks: ServerHooks = {
 				ctx.queryClient = createQueryClient(cache, ctx);
 			},
 
-			emitToDocumentHead() {
+			emitToSyncHeadScript() {
 				const newItemsString = uneval(cache._getNewItems());
-				return `<script>$RSC=${newItemsString}</script>`;
+				return `rakkas.cache=${newItemsString};`;
 			},
 
 			emitBeforeSsrChunk() {
 				if (cache._hasNewItems) {
 					const newItemsString = uneval(cache._getNewItems());
-					return `<script>Object.assign($RSC,${newItemsString})</script>`;
+					return `<script>Object.assign(rakkas.cache,${newItemsString})</script>`;
 				}
 			},
 		};

--- a/packages/rakkasjs/src/lib/types.ts
+++ b/packages/rakkasjs/src/lib/types.ts
@@ -6,3 +6,21 @@ export type {
 
 /** An object for storing stuff local to your app */
 export interface PageLocals {}
+
+/** An object for storing stuff local to your app */
+export interface RakkasBrowserGlobal {
+	/** Render as an SPA */
+	spa?: boolean;
+	/** Streaming cache */
+	cache?: Record<string, any>;
+	/** Action index */
+	actionIndex?: number;
+	/** Action data */
+	actionData?: any;
+	/** Dev only, force a rerender on HMR */
+	update?(): void;
+}
+
+declare global {
+	const rakkas: RakkasBrowserGlobal;
+}

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -55,7 +55,7 @@ export function App(props: AppProps) {
 
 	// TODO: Warn when a page doesn't export a default component
 
-	if (!import.meta.env.SSR) (window as any).$RAKKAS_UPDATE = update;
+	if (!import.meta.env.SSR) rakkas.update = update;
 
 	const pageContext = useContext(IsomorphicContext);
 
@@ -308,11 +308,8 @@ export async function loadRoute(
 						: module.default?.preload;
 
 				try {
-					if (
-						!import.meta.env.SSR &&
-						i === (window as any).$RAKKAS_ACTION_ERROR_INDEX
-					) {
-						delete (window as any).$RAKKAS_ACTION_ERROR_INDEX;
+					if (!import.meta.env.SSR && i === rakkas.actionIndex) {
+						delete rakkas.actionIndex;
 						throw new Error("Action error");
 					}
 					const preloaded =

--- a/packages/rakkasjs/src/runtime/client-entry.tsx
+++ b/packages/rakkasjs/src/runtime/client-entry.tsx
@@ -89,7 +89,7 @@ export async function startClient(
 	history.replaceState(
 		{
 			...history.state,
-			actionData: (window as any).$RAKKAS_ACTION_DATA,
+			actionData: rakkas.actionData,
 		},
 		"",
 	);
@@ -99,7 +99,7 @@ export async function startClient(
 		new URL(window.location.href),
 		undefined,
 		true,
-		(window as any).$RAKKAS_ACTION_DATA,
+		rakkas.actionData,
 	).catch((error) => {
 		return { error };
 	});
@@ -118,7 +118,5 @@ export async function startClient(
 
 	const container = document.getElementById("root")!;
 
-	(window as any).$RAKKAS_HYDRATE
-		? hydrateRoot(container, app)
-		: createRoot(container).render(app);
+	rakkas.spa ? createRoot(container).render(app) : hydrateRoot(container, app);
 }

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -74,7 +74,11 @@ export interface PageRequestHooks {
 	 */
 	wrapApp?: HookDefinition<(app: ReactElement) => ReactElement>;
 
-	/** Write to the document's head section */
+	/**
+	 * Write to the document's head section
+	 *
+	 * @deprecated Use the Head component or emitToSyncHeadScript hook instead.
+	 */
 	emitToDocumentHead?: HookDefinition<
 		(specialAttributes: {
 			htmlAttributes: Record<string, string | number | boolean | undefined>;
@@ -82,6 +86,9 @@ export interface PageRequestHooks {
 			bodyAttributes: Record<string, string | number | boolean | undefined>;
 		}) => ReactElement | string | undefined
 	>;
+
+	/** Emit code into the head section of the document */
+	emitToSyncHeadScript?: HookDefinition<() => string | undefined>;
 
 	/** Emit a chunk of HTML before each time React emits a chunk */
 	emitBeforeSsrChunk?: HookDefinition<() => string | undefined>;


### PR DESCRIPTION
This PR implements better ordering for children of the head element (inspired by [capo.js](https://rviscomi.github.io/capo.js/)).

In order to make this work best, `emitToDocumentHead` is now deprecated. Use the `useHead` hook, the `Head` component, or return a `head` property from your page/layout `preload` functions.

There's also a new `emitToSyncHeadScript` hook to emit some sync script content into the head which was a common use case for the `emitToDocumentHead` hook.