### PR TITLE
fix: make sure type extensions are always available

### DIFF
--- a/packages/rakkasjs/src/lib/index.ts
+++ b/packages/rakkasjs/src/lib/index.ts
@@ -51,3 +51,6 @@ export type {
 } from "../features/run-server-side/lib-client";
 
 export type { getRequestContext } from "../features/async-local-request-context/lib-server";
+
+export type {} from "../runtime/hattip-handler";
+export type {} from "../runtime/client-entry";


### PR DESCRIPTION
#194 caused some of the type extensions (e.g. `RequestContext.params`) not to be available unless the project imports `rakkasjs/server` somewhere. So, typically, if you had an API route but no `entry-hattip`, `ctx.params` would not be available in the types. This PR fixes it.