### PR TITLE
feat: managed head

### DIFF
--- a/packages/rakkasjs/src/features/head/implementation/Head.tsx
+++ b/packages/rakkasjs/src/features/head/implementation/Head.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useContext, useEffect } from "react";
 import { HeadContext } from "./context";
 import type { HeadProps } from "./types";
-import { NormalizedHeadProps, mergeHeadProps } from "./merge";
+import { Attributes, NormalizedHeadProps, mergeHeadProps } from "./merge";
 import { defaultHeadProps } from "./defaults";
 import { sortHeadTags } from "./sort";
 
@@ -94,7 +94,10 @@ function updateHead() {
 			break;
 		}
 
-		if (node.nodeType === Node.ELEMENT_NODE) {
+		if (
+			node.nodeType === Node.ELEMENT_NODE &&
+			!(node as HTMLElement).hasAttribute?.("data-sr")
+		) {
 			currentElements.push(node as HTMLElement);
 		}
 	}
@@ -102,12 +105,12 @@ function updateHead() {
 	let iNew = 0;
 	let iCur = 0;
 	while (iNew < newElements.length || iCur < currentElements.length) {
-		const newElement = newElements[iNew];
-		let currentElement = currentElements[iCur];
+		const newElement = newElements[iNew] as Attributes | undefined;
+		let currentElement = currentElements[iCur] as HTMLElement | undefined;
 
 		if (!newElement) {
 			do {
-				currentElement.remove();
+				currentElement?.remove();
 				currentElement = currentElements[++iCur];
 			} while (currentElement);
 			break;

--- a/packages/rakkasjs/src/features/head/implementation/types.ts
+++ b/packages/rakkasjs/src/features/head/implementation/types.ts
@@ -256,7 +256,7 @@ export interface CommonAttributes {
 	autofocus?: boolean;
 	class?: string | false;
 	contenteditable?: boolean;
-	["data-*"]?: string | false;
+	[key: `data-${string}`]: string | boolean;
 	dir?: "ltr" | "rtl" | "auto" | (string & {}) | false;
 	draggable?: boolean;
 	enterkeyhint?:

--- a/packages/rakkasjs/src/features/pages/middleware.tsx
+++ b/packages/rakkasjs/src/features/pages/middleware.tsx
@@ -707,10 +707,24 @@ function renderHead(
 ) {
 	// TODO: Customize HTML document
 
+	const browserGlobal: typeof rakkas = {};
+	if (actionErrorIndex >= 0 && renderMode !== "server") {
+		browserGlobal.actionErrorIndex = actionErrorIndex;
+	}
+
+	if (actionData !== undefined && renderMode !== "server") {
+		// TODO: Refactor this. Probably belongs to client-side-navigation
+		browserGlobal.actionData = actionData;
+	}
+
+	if (renderMode === "client") {
+		browserGlobal.clientRender = true;
+	}
+
 	const script: HeadElement = {
 		tagName: "script",
-		textContent: "",
 		"data-sr": true,
+		textContent: `rakkas=${uneval(browserGlobal)};`,
 	};
 
 	const emitToSyncHeadScriptHandlers = sortHooks(
@@ -765,19 +779,7 @@ function renderHead(
 			specialAttributes.htmlAttributes,
 		)}><head${stringifyAttributes(specialAttributes.headAttributes)}>` + result;
 
-	if (actionErrorIndex >= 0 && renderMode !== "server") {
-		result += `<script>$RAKKAS_ACTION_ERROR_INDEX=${actionErrorIndex}</script>`;
-	}
-
-	result +=
-		prefetchOutput +
-		(renderMode === "hydrate"
-			? `<script>$RAKKAS_HYDRATE="hydrate"</script>`
-			: "") +
-		// TODO: Refactor this. Probably belongs to client-side-navigation
-		(actionData === undefined && renderMode !== "server"
-			? ""
-			: `<script>$RAKKAS_ACTION_DATA=${uneval(actionData)}</script>`);
+	result += prefetchOutput;
 
 	if (import.meta.env.DEV) {
 		result +=

--- a/packages/rakkasjs/src/features/pages/middleware.tsx
+++ b/packages/rakkasjs/src/features/pages/middleware.tsx
@@ -45,7 +45,7 @@ export default async function renderPageRoute(
 		return;
 	}
 
-	const pageHooks = ctx.hooks.map((hook) => hook.createPageHooks?.(ctx));
+	const pageHooks = ctx.rakkas.hooks.map((hook) => hook.createPageHooks?.(ctx));
 
 	const extendPageContextHandlers = sortHooks([
 		...pageHooks.map((hook) => hook?.extendPageContext),
@@ -86,7 +86,7 @@ export default async function renderPageRoute(
 		  >
 		| undefined;
 
-	if (ctx.notFound) {
+	if (ctx.rakkas.notFound) {
 		do {
 			if (!pathname.endsWith("/")) {
 				pathname += "/";
@@ -294,7 +294,7 @@ export default async function renderPageRoute(
 		});
 	}
 
-	status = actionResult?.status ?? (ctx.notFound ? 404 : 200);
+	status = actionResult?.status ?? (ctx.rakkas.notFound ? 404 : 200);
 
 	pageContext.actionData = actionResult?.data;
 	preloadContext.actionData = actionResult?.data;

--- a/packages/rakkasjs/src/features/use-query/client-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/client-hooks.tsx
@@ -18,9 +18,6 @@ export default defineClientHooks({
 	},
 });
 
-// Rakkas Suspense Cache
-declare const $RSC: Record<string, any> | undefined;
-
 const queryCache: Record<string, CacheItem | undefined> = Object.create(null);
 
 export function resetErrors() {
@@ -59,20 +56,20 @@ const cache: QueryCache = {
 	},
 
 	has(key: string) {
-		return key in queryCache || (typeof $RSC !== "undefined" && key in $RSC);
+		return key in queryCache || (!!rakkas.cache && key in rakkas.cache);
 	},
 
 	get(key: string) {
-		if (!queryCache[key] && typeof $RSC !== "undefined" && key in $RSC) {
+		if (!queryCache[key] && rakkas.cache && key in rakkas.cache) {
 			queryCache[key] = {
-				value: $RSC[key],
+				value: rakkas.cache[key],
 				subscribers: new Set(),
 				date: Date.now(),
 				hydrated: true,
 				cacheTime: DEFAULT_QUERY_OPTIONS.cacheTime,
 			};
 
-			delete $RSC[key];
+			delete rakkas.cache[key];
 		}
 
 		return queryCache[key];

--- a/packages/rakkasjs/src/features/use-query/server-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/server-hooks.tsx
@@ -94,9 +94,9 @@ const useQueryServerHooks: ServerHooks = {
 				ctx.queryClient = createQueryClient(cache, ctx);
 			},
 
-			emitToDocumentHead() {
+			emitToSyncHeadScript() {
 				const newItemsString = uneval(cache._getNewItems());
-				return `<script>$RSC=${newItemsString}</script>`;
+				return `$RSC=${newItemsString};`;
 			},
 
 			emitBeforeSsrChunk() {

--- a/packages/rakkasjs/src/features/use-query/server-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/server-hooks.tsx
@@ -96,13 +96,13 @@ const useQueryServerHooks: ServerHooks = {
 
 			emitToSyncHeadScript() {
 				const newItemsString = uneval(cache._getNewItems());
-				return `$RSC=${newItemsString};`;
+				return `rakkas.cache=${newItemsString};`;
 			},
 
 			emitBeforeSsrChunk() {
 				if (cache._hasNewItems) {
 					const newItemsString = uneval(cache._getNewItems());
-					return `<script>Object.assign($RSC,${newItemsString})</script>`;
+					return `<script>Object.assign(rakkas.cache,${newItemsString})</script>`;
 				}
 			},
 		};

--- a/packages/rakkasjs/src/lib/types.ts
+++ b/packages/rakkasjs/src/lib/types.ts
@@ -6,3 +6,13 @@ export type {
 
 /** An object for storing stuff local to your app */
 export interface PageLocals {}
+
+declare global {
+	/** Browser global for holding Rakkas specific data */
+	const rakkas: {
+		cache?: Record<string, any>;
+		actionErrorIndex?: number;
+		actionData?: any;
+		clientRender?: boolean;
+	};
+}

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -308,11 +308,8 @@ export async function loadRoute(
 						: module.default?.preload;
 
 				try {
-					if (
-						!import.meta.env.SSR &&
-						i === (window as any).$RAKKAS_ACTION_ERROR_INDEX
-					) {
-						delete (window as any).$RAKKAS_ACTION_ERROR_INDEX;
+					if (!import.meta.env.SSR && i === rakkas.actionErrorIndex) {
+						delete rakkas.actionErrorIndex;
 						throw new Error("Action error");
 					}
 					const preloaded =

--- a/packages/rakkasjs/src/runtime/client-entry.tsx
+++ b/packages/rakkasjs/src/runtime/client-entry.tsx
@@ -89,7 +89,7 @@ export async function startClient(
 	history.replaceState(
 		{
 			...history.state,
-			actionData: (window as any).$RAKKAS_ACTION_DATA,
+			actionData: rakkas.actionData,
 		},
 		"",
 	);
@@ -99,7 +99,7 @@ export async function startClient(
 		new URL(window.location.href),
 		undefined,
 		true,
-		(window as any).$RAKKAS_ACTION_DATA,
+		rakkas.actionData,
 	).catch((error) => {
 		return { error };
 	});
@@ -118,7 +118,7 @@ export async function startClient(
 
 	const container = document.getElementById("root")!;
 
-	(window as any).$RAKKAS_HYDRATE
-		? hydrateRoot(container, app)
-		: createRoot(container).render(app);
+	rakkas.clientRender
+		? createRoot(container).render(app)
+		: hydrateRoot(container, app);
 }

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -15,10 +15,17 @@ declare module "@hattip/compose" {
 		params: Record<string, string>;
 		/** Isomorphic fetch function */
 		fetch: typeof fetch;
-		/** Server-side customiization hooks */
-		hooks: ServerHooks[];
-		/** Set to true when searching for a not found page */
-		notFound?: boolean;
+		/**
+		 * Internal stuff, don't use it in user code.
+		 *
+		 * @internal
+		 */
+		rakkas: {
+			/** Server-side customiization hooks */
+			hooks: ServerHooks[];
+			/** Set to true when searching for a not found page */
+			notFound: boolean;
+		};
 	}
 }
 
@@ -158,12 +165,15 @@ export function createRequestHandler(
 
 function init(hooks: ServerHooks[]) {
 	return (ctx: RequestContext) => {
-		ctx.hooks = hooks;
+		ctx.rakkas = {
+			hooks,
+			notFound: false,
+		};
 	};
 }
 
 function notFound(ctx: RequestContext) {
-	ctx.notFound = true;
+	ctx.rakkas.notFound = true;
 }
 
 async function prerender(ctx: RequestContext) {

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -7,7 +7,8 @@ import serverFeatureHooks from "./feature-server-hooks";
 import { HookDefinition, sortHooks } from "./utils";
 import pluginFactories from "rakkasjs:plugin-server-hooks";
 import * as commonHooksModule from "rakkasjs:common-hooks";
-import { CommonPluginOptions } from "./common-hooks";
+import type { CommonPluginOptions } from "./common-hooks";
+import type { NormalizedHeadProps } from "../features/head/implementation/merge";
 
 declare module "@hattip/compose" {
 	interface RequestContextExtensions {
@@ -25,6 +26,8 @@ declare module "@hattip/compose" {
 			hooks: ServerHooks[];
 			/** Set to true when searching for a not found page */
 			notFound: boolean;
+			/** Head tags */
+			head: NormalizedHeadProps;
 		};
 	}
 }
@@ -82,13 +85,7 @@ export interface PageRequestHooks {
 	wrapApp?: HookDefinition<(app: ReactElement) => ReactElement>;
 
 	/** Write to the document's head section */
-	emitToDocumentHead?: HookDefinition<
-		(specialAttributes: {
-			htmlAttributes: Record<string, string | number | boolean | undefined>;
-			headAttributes: Record<string, string | number | boolean | undefined>;
-			bodyAttributes: Record<string, string | number | boolean | undefined>;
-		}) => ReactElement | string | undefined
-	>;
+	emitToDocumentHead?: HookDefinition<() => ReactElement | string | undefined>;
 
 	/** Emit a chunk of HTML before each time React emits a chunk */
 	emitBeforeSsrChunk?: HookDefinition<() => string | undefined>;
@@ -168,6 +165,10 @@ function init(hooks: ServerHooks[]) {
 		ctx.rakkas = {
 			hooks,
 			notFound: false,
+			head: {
+				keyed: {},
+				unkeyed: [],
+			},
 		};
 	};
 }

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -9,6 +9,7 @@ import pluginFactories from "rakkasjs:plugin-server-hooks";
 import * as commonHooksModule from "rakkasjs:common-hooks";
 import type { CommonPluginOptions } from "./common-hooks";
 import type { NormalizedHeadProps } from "../features/head/implementation/merge";
+import { HeadElement } from "../features/head/implementation/types";
 
 declare module "@hattip/compose" {
 	interface RequestContextExtensions {
@@ -84,8 +85,19 @@ export interface PageRequestHooks {
 	 */
 	wrapApp?: HookDefinition<(app: ReactElement) => ReactElement>;
 
-	/** Write to the document's head section */
+	/**
+	 * Write to the document's head section.
+	 *
+	 * @deprecated Use `emitToSyncHeadScript`, `emitServerOnlyHeadElements` or
+	 * the normal Head component instead.
+	 */
 	emitToDocumentHead?: HookDefinition<() => ReactElement | string | undefined>;
+
+	/** Write to the document's head section */
+	emitServerOnlyHeadElements?: HookDefinition<() => HeadElement[] | undefined>;
+
+	/** Emit a piece of code to be inserted into a script tag in the head. */
+	emitToSyncHeadScript?: HookDefinition<() => string | undefined>;
 
 	/** Emit a chunk of HTML before each time React emits a chunk */
 	emitBeforeSsrChunk?: HookDefinition<() => string | undefined>;


### PR DESCRIPTION
The new head handling has a head element sorter inspired by [capo.js](https://rviscomi.github.io/capo.js/) but it was only used for user-supplied elements since Rakkas itself used plain strings to serialize the preload links and other head elements it generated. With this PR, we switch to using the same logic for all head elements except those emitted by the (**now deprecated**) `emitToDocumentHead` hook.

Instead of the deprecated `emitToDocumentHead`, we now recommend `emitServerOnlyHeadElements` and `emitToSyncHeadScript`. The letter emits code inside a synchronous sloppy mode script tag in the head.

Also several scattered browser globals are now neatly tucked into a single `rakkas` global.
