### PR TITLE
feat: ability to set headers in server-side functions

### DIFF
--- a/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
+++ b/packages/rakkasjs/src/features/run-server-side/lib-client.tsx
@@ -1,6 +1,7 @@
 import { QueryResult, useQuery } from "../use-query/lib";
 import { stringify } from "@brillout/json-serializer/stringify";
 import {
+	RunServerSideContext,
 	RunServerSideMutationOptions,
 	RunServerSideQueryOptions,
 	ServerSideFunction,
@@ -204,7 +205,7 @@ export const runServerSideMutation: <T>(
  * @param options Options for the mutation
  */
 export const useServerSideMutation: <T, V = void>(
-	fn: (context: RequestContext, vars: V) => T | Promise<T>,
+	fn: (context: RunServerSideContext, vars: V) => T | Promise<T>,
 	options?: UseServerSideMutationOptions<T, V>,
 ) => UseMutationResult<T, V> = useSSMImpl as any;
 

--- a/packages/rakkasjs/src/features/run-server-side/lib-common.ts
+++ b/packages/rakkasjs/src/features/run-server-side/lib-common.ts
@@ -19,7 +19,14 @@ export function useRequestContext() {
 }
 
 /** Callback passed to useServerSide/runServerside family of functions */
-export type ServerSideFunction<T> = (context: RequestContext) => T | Promise<T>;
+export type ServerSideFunction<T> = (
+	context: RunServerSideContext,
+) => T | Promise<T>;
+
+export interface RunServerSideContext extends RequestContext {
+	/** Response headers. Especially useful for setting cache control headers. */
+	headers: Headers;
+}
 
 /** Options for {@link runServerSideQuery} */
 export interface RunServerSideQueryOptions {
@@ -92,5 +99,5 @@ export type UseFormMutationResult<T> = {
 );
 
 export type UseFormMutationFn<T> = (
-	context: RequestContext,
+	context: RunServerSideContext,
 ) => ActionResult<T> | Promise<ActionResult<T>>;

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -730,6 +730,19 @@ function testCase(
 			);
 		});
 
+		test.runIf(!dev)("runSSQ honors uniqueId", async () => {
+			const result = await fetch(host + "/_app/data/id/customId/2/5/d.js")
+				.then((r) => r.text())
+				.then((t) => (0, eval)(`(${t})`));
+
+			expect(result).toMatchObject({ result: 7, ssr: true });
+		});
+
+		test.runIf(!dev)("runSSQ sets headers", async () => {
+			const result = await fetch(host + "/_app/data/id/customId/2/5/d.js");
+			expect(result.headers.get("x-test")).toBe("test");
+		});
+
 		test("runs runServerSideMutation on the server", async () => {
 			await page.goto(host + "/run-ssm");
 			await page.waitForSelector(".hydrated");

--- a/testbed/kitchen-sink/src/routes/run-ssq/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/run-ssq/index.page.tsx
@@ -7,10 +7,14 @@ export default function UseSsq() {
 	const fetched1 = useQuery("run-ssq-1", (ctx) => {
 		return runServerSideQuery(
 			ctx.requestContext,
-			() => ({
-				result: a + b,
-				ssr: import.meta.env.SSR,
-			}),
+			(ctx) => {
+				ctx.headers.set("x-test", "test");
+
+				return {
+					result: a + b,
+					ssr: import.meta.env.SSR,
+				};
+			},
 			{ uniqueId: "customId" },
 		);
 	});


### PR DESCRIPTION
This PR allows one to set headers in server-side functions. The context object now contains a `headers` property which is an instance of the standard `Headers` object.

The main use case is to set the `cache-control` header.