### PR TITLE
feat: implement navigation blocking

### DIFF
--- a/packages/rakkasjs/src/features/client-side-navigation/lib.tsx
+++ b/packages/rakkasjs/src/features/client-side-navigation/lib.tsx
@@ -14,4 +14,5 @@ export {
 	useSubmit,
 	cancelLastNavigation,
 	prefetchRoute,
+	useNavigationBlocker,
 } from "./implementation";

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1223,6 +1223,7 @@ function testCase(
 			await page.goto(host + "/blocker");
 			await page.waitForSelector(".hydrated");
 
+			await page.waitForSelector("input", { timeout: 10_000 });
 			await page.type("input", "Hello");
 
 			await page.click("a");
@@ -1240,13 +1241,14 @@ function testCase(
 			await page.waitForFunction(() =>
 				window.location.href.includes("elsewhere"),
 			);
-		});
+		}, 20_000);
 
 		test("blocks back navigation", async () => {
 			await page.goto(host + "/blocker/elsewhere");
 			await page.waitForSelector(".hydrated");
 			await page.click("a");
 
+			await page.waitForSelector("input", { timeout: 10_000 });
 			await page.type("input", "Hello");
 
 			await page.goBack();
@@ -1264,7 +1266,7 @@ function testCase(
 			await page.waitForFunction(() =>
 				window.location.href.includes("elsewhere"),
 			);
-		});
+		}, 20_000);
 	});
 }
 

--- a/testbed/kitchen-sink/ci.test.ts
+++ b/testbed/kitchen-sink/ci.test.ts
@@ -1218,6 +1218,53 @@ function testCase(
 					document.body?.innerText.includes("data3: 1"),
 			);
 		});
+
+		test("blocks link navigation", async () => {
+			await page.goto(host + "/blocker");
+			await page.waitForSelector(".hydrated");
+
+			await page.type("input", "Hello");
+
+			await page.click("a");
+			await page.click("#stay");
+
+			await page.waitForFunction(() => !document.getElementById("stay"));
+			await page.waitForFunction(
+				() => !window.location.href.includes("elsewhere"),
+			);
+
+			await page.click("a");
+			await page.click("#leave");
+
+			await page.waitForFunction(() => !document.getElementById("leave"));
+			await page.waitForFunction(() =>
+				window.location.href.includes("elsewhere"),
+			);
+		});
+
+		test("blocks back navigation", async () => {
+			await page.goto(host + "/blocker/elsewhere");
+			await page.waitForSelector(".hydrated");
+			await page.click("a");
+
+			await page.type("input", "Hello");
+
+			await page.goBack();
+			await page.click("#stay");
+
+			await page.waitForFunction(() => !document.getElementById("stay"));
+			await page.waitForFunction(
+				() => !window.location.href.includes("elsewhere"),
+			);
+
+			await page.goBack();
+			await page.click("#leave");
+
+			await page.waitForFunction(() => !document.getElementById("leave"));
+			await page.waitForFunction(() =>
+				window.location.href.includes("elsewhere"),
+			);
+		});
 	});
 }
 

--- a/testbed/kitchen-sink/src/routes/blocker/(blocker).page.tsx
+++ b/testbed/kitchen-sink/src/routes/blocker/(blocker).page.tsx
@@ -1,0 +1,40 @@
+import { Link, useNavigationBlocker } from "rakkasjs";
+import { useState } from "react";
+
+export default function Blocker() {
+	const [text, setText] = useState("");
+	const blocker = useNavigationBlocker(text.trim() !== "");
+
+	return (
+		<div>
+			<p>
+				<input
+					type="text"
+					value={text}
+					onChange={(e) => setText(e.target.value)}
+				/>
+				&nbsp;
+				<button onClick={() => setText("")}>Clear</button>
+			</p>
+			<p>
+				<Link href="/blocker/elsewhere">Go elsewhere</Link>
+			</p>
+			{blocker.isBlocking && (
+				<>
+					<p>
+						You have unsaved changes. Are you sure you want to leave this page?
+					</p>
+					<p>
+						<button id="leave" onClick={blocker.leave}>
+							Yes, leave
+						</button>
+						&nbsp;
+						<button id="stay" onClick={blocker.stay}>
+							No, stay
+						</button>
+					</p>
+				</>
+			)}
+		</div>
+	);
+}

--- a/testbed/kitchen-sink/src/routes/blocker/elsewhere.page.tsx
+++ b/testbed/kitchen-sink/src/routes/blocker/elsewhere.page.tsx
@@ -1,0 +1,11 @@
+import { Link } from "rakkasjs";
+
+export default function BlockerElsewhere() {
+	return (
+		<div>
+			<p>
+				<Link href="/blocker">Go the blocker page</Link>
+			</p>
+		</div>
+	);
+}


### PR DESCRIPTION
This PR implements navigation blocking.

The `useNavigationBlocker` hook takes a condition parameter that enables navigation blocking when set to true. When enabled, the hook will return an object with `isBlocking` set to `true`. The `leave` method will allow the navigation to proceed, while the `stay` method will keep the navigation from happening.

Rakkas will also install an `onBeforeUnload` event handler if there are active navigation blockers on the page to warn the user if they close the tab or navigate away to a different site.

```tsx
const [text, setText] = useState("");
const blocker = useNavigationBlocker(text.trim() !== "");

return (
  <div>
    <p>
      <input
        type="text"
        value={text}
        onChange={(e) => setText(e.target.value)}
      />
      &nbsp;
      <button onClick={() => setText("")}>Clear</button>
    </p>
    <p>
      <Link href="/blocker/elsewhere">Go elsewhere</Link>
    </p>
    {blocker.isBlocking && (
      <>
        <p>
          You have unsaved changes. Are you sure you want to leave this page?
        </p>
        <p>
          <button id="leave" onClick={blocker.leave}>
            Yes, leave
          </button>
          &nbsp;
          <button id="stay" onClick={blocker.stay}>
            No, stay
          </button>
        </p>
      </>
    )}
  </div>
);

```
