### PR TITLE
feat: allow overriding the default document title

### DIFF
--- a/packages/rakkasjs/src/features/head/implementation/defaults.ts
+++ b/packages/rakkasjs/src/features/head/implementation/defaults.ts
@@ -1,7 +1,7 @@
 import { HeadProps } from "./types";
 
 export const defaultHeadProps: HeadProps = {
-	title: "Rakkas App",
+	title: import.meta.env.RAKKAS_DEFAULT_APP_TITLE || "Rakkas App",
 	viewport: "width=device-width, initial-scale=1",
 	htmlAttributes: { lang: "en" },
 	elements: [{ charset: "utf-8" }],


### PR DESCRIPTION
This PR allows overriding the default document title via the `RAKKAS_DEFAULT_APP_TITLE` env var. This is needed because the default title ("Rakkas App") can leak to the browser in some cases (when doing client rendering or if the outermost layout throws, for example).

Currently it's a build-time setting, the runtime value of the env var is not taken into consideration. It's probably a better idea to move it into a page hook.