### PR TITLE
fix: don't scroll non-window elements to the top

### DIFF
--- a/packages/rakkasjs/src/features/client-side-navigation/implementation/history.ts
+++ b/packages/rakkasjs/src/features/client-side-navigation/implementation/history.ts
@@ -274,13 +274,12 @@ export function restoreScrollPosition() {
 		const pos = entry.elements?.get(id);
 		if (pos) {
 			el.scrollTo(pos.x, pos.y);
-		} else {
-			el.scrollTo(0, 0);
 		}
 	}
 }
 
 let lastSavedGroupId: string | undefined;
+
 function saveScrollPosition(id: string) {
 	const entry = getNavigationEntry(id)!;
 	lastSavedGroupId = entry.scrollGroupId;


### PR DESCRIPTION
This behavior is only desirable when the sam DOM element changes its `data-rakkas-scroll-id` between navigations. In that case, the effect can be achieved by also giving a key to that element.