### PR TITLE
fix: cleaner way to rerun preload functions after HMR

### DIFF
--- a/packages/rakkasjs/src/features/pages/vite-plugin.ts
+++ b/packages/rakkasjs/src/features/pages/vite-plugin.ts
@@ -110,9 +110,13 @@ export default function pages(): Plugin {
 
 const PAGE_HOT_RELOAD = `
 	if (import.meta.hot) {
-		import.meta.hot.accept(() => {
-			console.log("Update", import.meta.url);
-			rakkas.update?.();
+		RefreshRuntime.__hmr_import(import.meta.url).then((currentExports) => {
+			import.meta.hot.accept((nextExports) => {
+				if (currentExports.default) {
+					currentExports.default.preload = nextExports.default?.preload;
+				}
+				rakkas.update?.();
+			});
 		});
 	}
 `;


### PR DESCRIPTION
The old way was leaking memory and still not catching all cases. It is much cleaner to copy the new preload function into the new one.