### PR TITLE
feat: allow Rakkas plugins to receive static config options

### DIFF
--- a/packages/rakkasjs/src/runtime/client-entry.tsx
+++ b/packages/rakkasjs/src/runtime/client-entry.tsx
@@ -14,7 +14,9 @@ import ErrorComponent from "rakkasjs:error-page";
 import type { PageContext } from "./page-types";
 import { sortHooks } from "./utils";
 import { commonHooks } from "./feature-common-hooks";
-import factories from "rakkasjs:plugin-client-hooks";
+import factories, {
+	options as configOptions,
+} from "rakkasjs:plugin-client-hooks";
 import * as commonHooksModule from "rakkasjs:common-hooks";
 
 export type { ClientHooks };
@@ -32,6 +34,7 @@ export interface ClientPluginOptions {}
 export type ClientPluginFactory = (
 	options: ClientPluginOptions,
 	commonOptions: CommonPluginOptions,
+	configOptions: any,
 ) => ClientHooks;
 
 /** Starts the client. */
@@ -44,7 +47,9 @@ export async function startClient(
 	const { commonPluginOptions = {} } = commonHooksModule;
 
 	const hooks = [
-		...factories.map((factory) => factory(pluginOptions, commonPluginOptions)),
+		...factories.map((factory, i) =>
+			factory(pluginOptions, commonPluginOptions, configOptions[i]),
+		),
 		...featureClientHooks,
 	];
 

--- a/packages/rakkasjs/src/runtime/common-hooks.ts
+++ b/packages/rakkasjs/src/runtime/common-hooks.ts
@@ -32,4 +32,7 @@ export interface CommonHooks {
 
 export interface CommonPluginOptions {}
 
-export type CommonPluginFactory = (options: CommonPluginOptions) => CommonHooks;
+export type CommonPluginFactory = (
+	options: CommonPluginOptions,
+	configOptions: any,
+) => CommonHooks;

--- a/packages/rakkasjs/src/runtime/feature-common-hooks.ts
+++ b/packages/rakkasjs/src/runtime/feature-common-hooks.ts
@@ -1,11 +1,13 @@
 import * as commonHooksModule from "rakkasjs:common-hooks";
-import pluginFactories from "rakkasjs:plugin-common-hooks";
+import pluginFactories, {
+	options as configOptions,
+} from "rakkasjs:plugin-common-hooks";
 import type { CommonHooks } from "./common-hooks";
 
 export const commonHooks: CommonHooks[] = [
-	...pluginFactories.map((factory) => {
+	...pluginFactories.map((factory, i) => {
 		const { commonPluginOptions = {} } = commonHooksModule;
-		return factory(commonPluginOptions);
+		return factory(commonPluginOptions, configOptions[i]);
 	}),
 	commonHooksModule.default,
 ];

--- a/packages/rakkasjs/src/runtime/hattip-handler.ts
+++ b/packages/rakkasjs/src/runtime/hattip-handler.ts
@@ -9,7 +9,9 @@ import renderPageRoute from "../features/pages/middleware";
 import type { PageContext } from "../runtime/page-types";
 import serverFeatureHooks from "./feature-server-hooks";
 import { type HookDefinition, sortHooks } from "./utils";
-import pluginFactories from "rakkasjs:plugin-server-hooks";
+import pluginFactories, {
+	options as configOptions,
+} from "rakkasjs:plugin-server-hooks";
 import * as commonHooksModule from "rakkasjs:common-hooks";
 import type { CommonPluginOptions } from "./common-hooks";
 import type {
@@ -74,6 +76,7 @@ export interface ServerPluginOptions {}
 export type ServerPluginFactory = (
 	options: ServerPluginOptions,
 	commonOptions: CommonPluginOptions,
+	configOptions: any,
 ) => ServerHooks;
 
 /** Hooks for customizing the page rendering on the server */
@@ -122,9 +125,9 @@ export function createRequestHandler<T>(
 	pluginOptions: ServerPluginOptions = {},
 ): HattipHandler<T> {
 	const hooks = [
-		...pluginFactories.map((factory) => {
+		...pluginFactories.map((factory, i) => {
 			const { commonPluginOptions = {} } = commonHooksModule;
-			return factory(pluginOptions, commonPluginOptions);
+			return factory(pluginOptions, commonPluginOptions, configOptions[i]);
 		}),
 		...serverFeatureHooks,
 		userHooks,

--- a/packages/rakkasjs/src/runtime/virtual-modules.d.ts
+++ b/packages/rakkasjs/src/runtime/virtual-modules.d.ts
@@ -115,10 +115,13 @@ declare module "rakkasjs:plugin-server-hooks" {
 		(
 			serverOptions: ServerPluginOptions,
 			commonOptions: CommonPluginOptions,
+			configOptions: unknown,
 		) => ServerHooks
 	>;
 
 	export default pluginServerHookFactories;
+
+	export const options: unknown[];
 }
 
 declare module "rakkasjs:plugin-client-hooks" {
@@ -130,15 +133,22 @@ declare module "rakkasjs:plugin-client-hooks" {
 		(
 			clientOptions: ClientPluginOptions,
 			commonOptions: CommonPluginOptions,
+			configOptions: unknown,
 		) => ClientHooks
 	>;
+
 	export default pluginClientHookFactories;
+
+	export const options: unknown[];
 }
 
 declare module "rakkasjs:plugin-common-hooks" {
 	import { CommonHooks, CommonPluginOptions } from "./common-hooks";
 	const pluginCommonHookFactories: Array<
-		(commonOptions: CommonPluginOptions) => CommonHooks
+		(commonOptions: CommonPluginOptions, configOptions: unknown) => CommonHooks
 	>;
+
 	export default pluginCommonHookFactories;
+
+	export const options: unknown[];
 }


### PR DESCRIPTION
`api.rakkas.xxxHooks` options now accept another form that allows to pass static configuration options to the plugin factory:

```ts
export function rakkasTanstackQuery(): Plugin {
  return {
    name: "my-rakkas-plugin",
    api: {
      rakkas: {
        // Instead of
        // clientHooks: "/plugin/client-hooks.tsx",
        clientHooks: { 
          specifier: "/plugin/client-hooks.tsx",
          options: { hello: "world" },
      },
    },
  };
}
```

The config options will be serialized with `devalue` and passed to the plugin factory function as the third (for client and server hooks) or the second (for common hooks) argument.