### PR TITLE
fix: useFormMutation parse error

### DIFF
--- a/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
+++ b/packages/rakkasjs/src/features/run-server-side/server-hooks.ts
@@ -12,7 +12,10 @@ const runServerSideServerHooks: ServerHooks = {
 		beforePages: [
 			async (ctx) => {
 				const prefix = `/_app/data/`;
-				let action = ctx.url.searchParams.get("_action");
+				let action =
+					ctx.method !== "POST"
+						? undefined
+						: ctx.url.searchParams.get("_action");
 
 				if (!ctx.url.pathname.startsWith(prefix) && !action) {
 					return;
@@ -63,7 +66,7 @@ const runServerSideServerHooks: ServerHooks = {
 					} else {
 						if (ctx.method === "GET") {
 							// Remove path segment /d.js at the end
-							closure.length -= 1;
+							closure.length = Math.max(0, closure.length - 1);
 							isFormMutation = false;
 						}
 


### PR DESCRIPTION
This PR fixes `useFormMutation` throwing a parse error in certain cases when progressive enhancement wasn't used.