### PR TITLE
feat: allow async page guards

### DIFF
--- a/examples/session/readme.md
+++ b/examples/session/readme.md
@@ -3,6 +3,7 @@
 > **This example requires Node.js 16 or newer.**
 
 This example shows how to handle sessions with Rakkas. It's a toy e-commerce store that allows you to sign up, sign in, add items to your cart, and remove them.
+
 It uses [HatTip session middleware](https://github.com/hattipjs/hattip/tree/main/packages/middleware/session) with `EncryptedCookieStore` which doesn't require any database. It stores users and products in memory but it could be easily replaced with a real database.
 
 The `EncryptedCookieStore` requires a secret key to encrypt the session data. You can generate a random key with `node scripts/generate-key` and put it in a `.env` file at the root of the project like this:

--- a/examples/session/src/routes/sign-up.page.tsx
+++ b/examples/session/src/routes/sign-up.page.tsx
@@ -12,15 +12,9 @@ import { users } from "src/data/users";
 export default function SignUpPage() {
 	const queryClient = useQueryClient();
 
-	const passwordRef = useRef<HTMLInputElement>(null);
-
-	const { submitHandler, data } = useSubmit({
-		onSuccess: () => {
-			if (data) {
-				// Data means, unintuitively, there was an error
-				// Let's clear the password field
-				passwordRef.current!.value = "";
-			} else {
+	const { submitHandler, data } = useSubmit<{ error?: string }>({
+		onSuccess: (result) => {
+			if (!result.error) {
 				queryClient.invalidateQueries("session");
 			}
 		},
@@ -34,7 +28,7 @@ export default function SignUpPage() {
 				<label>
 					User name:
 					<br />
-					<input type="text" name="userName" defaultValue={data?.userName} />
+					<input type="text" name="userName" />
 				</label>
 			</p>
 
@@ -42,7 +36,7 @@ export default function SignUpPage() {
 				<label>
 					Password:
 					<br />
-					<input type="password" name="password" ref={passwordRef} />
+					<input type="password" name="password" />
 				</label>
 			</p>
 
@@ -59,7 +53,7 @@ export default function SignUpPage() {
 	);
 }
 
-export const action: ActionHandler = async (ctx) => {
+export const action: ActionHandler<{ error?: string }> = async (ctx) => {
 	const fd = await ctx.requestContext.request.formData();
 	const userName = fd.get("userName");
 	const password = fd.get("password");
@@ -101,5 +95,8 @@ export const action: ActionHandler = async (ctx) => {
 	// session ID to prevent session fixation attacks.
 	await ctx.requestContext.session.regenerate();
 
-	return { redirect: "/" };
+	return {
+		redirect: "/",
+		data: {},
+	};
 };

--- a/packages/rakkasjs/src/features/client-side-navigation/implementation/link.tsx
+++ b/packages/rakkasjs/src/features/client-side-navigation/implementation/link.tsx
@@ -331,23 +331,25 @@ function shouldHandleClick(e: MouseEventLike): boolean {
 	);
 }
 
-export type UseSubmitResult = {
+export type UseSubmitResult<T = any> = {
 	submitHandler(event: FormEvent<HTMLFormElement>): void;
 } & (
 	| UseMutationIdleResult
 	| UseMutationLoadingResult
 	| UseMutationErrorResult
-	| UseMutationSuccessResult<any>
+	| UseMutationSuccessResult<T>
 );
 
-export type UseSubmitOptions = UseMutationOptions<
-	any,
+export type UseSubmitOptions<T> = UseMutationOptions<
+	T,
 	{ form: HTMLFormElement; formData: FormData }
 > &
 	Omit<NavigationOptions, "actionData">;
 
 // TODO: Where does this belong?
-export function useSubmit(options?: UseSubmitOptions): UseSubmitResult {
+export function useSubmit<T>(
+	options?: UseSubmitOptions<T>,
+): UseSubmitResult<T> {
 	const { current } = useLocation();
 	const pageContext = usePageContext();
 
@@ -375,20 +377,20 @@ export function useSubmit(options?: UseSubmitOptions): UseSubmitResult {
 			});
 
 			const text = await response.text();
-			const value: ActionResult<any> = (0, eval)("(" + text + ")");
+			const value: ActionResult<T> = (0, eval)("(" + text + ")");
 
 			return value;
 		},
 		{
 			...options,
 			onSuccess(value) {
+				options?.onSuccess?.(value.data);
+
 				if ("redirect" in value) {
 					navigate(value.redirect, {
 						...options,
 					}).catch(ignore);
 				} else {
-					options?.onSuccess?.(value.data);
-
 					navigate(current, {
 						replace: true,
 						...options,

--- a/packages/rakkasjs/src/features/pages/middleware.tsx
+++ b/packages/rakkasjs/src/features/pages/middleware.tsx
@@ -97,13 +97,13 @@ export default async function renderPageRoute(
 				pathname += "/";
 			}
 
-			found = findPage(
+			found = (await findPage(
 				notFoundRoutes,
 				ctx.url,
 				pathname + "$404",
 				pageContext,
 				true,
-			) as any;
+			)) as any;
 
 			if (found) {
 				break;
@@ -128,7 +128,13 @@ export default async function renderPageRoute(
 		} while (!found);
 	} else {
 		pathname = ctx.url.pathname;
-		const result = findPage(routes, ctx.url, pathname, pageContext, false);
+		const result = await findPage(
+			routes,
+			ctx.url,
+			pathname,
+			pageContext,
+			false,
+		);
 
 		found = result;
 
@@ -298,13 +304,13 @@ export default async function renderPageRoute(
 		});
 	}
 
-	if (actionResult && "redirect" in actionResult) {
-		const location = String(actionResult.redirect);
+	if (actionResult && actionResult.redirect) {
+		const location = new URL(actionResult.redirect, ctx.url.origin).href;
 		return new Response(redirectBody(location), {
-			status: actionResult.status ?? actionResult.permanent ? 301 : 302,
+			status: actionResult.status ?? 302,
 			headers: makeHeaders(
 				{
-					location: new URL(location, ctx.url.origin).href,
+					location,
 					"content-type": "text/html; charset=utf-8",
 					vary: "accept",
 				},

--- a/packages/rakkasjs/src/internal/find-page.tsx
+++ b/packages/rakkasjs/src/internal/find-page.tsx
@@ -7,7 +7,7 @@ export const beforePageLookupHandlers = sortHooks(
 	commonHooks.map((hook) => hook.beforePageLookup),
 );
 
-export function findPage<
+export async function findPage<
 	T extends
 		| (typeof import("rakkasjs:server-page-routes").default)[0]
 		| (typeof import("rakkasjs:client-page-routes").default)[0],
@@ -17,7 +17,7 @@ export function findPage<
 	path: string,
 	pageContext: PageContext,
 	notFound: boolean,
-): RouteMatch<T> | Redirection | undefined {
+): Promise<RouteMatch<T> | Redirection | undefined> {
 	let rewritten: boolean;
 	let renderedUrl: URL = url;
 
@@ -56,7 +56,11 @@ export function findPage<
 			const guards = (route[2] as Array<PageRouteGuard>) || [];
 
 			for (const guard of guards) {
-				const result = guard(guardContext);
+				let result = guard(guardContext);
+				if (result instanceof Promise) {
+					result = await result;
+				}
+
 				if (!result) {
 					// Try next match
 					continue outer;

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -184,7 +184,7 @@ export async function loadRoute(
 		const notFoundRoutes = prodModule.notFoundRoutes;
 
 		let pathname = url.pathname;
-		const result = findPage(routes, url, pathname, pageContext, false);
+		const result = await findPage(routes, url, pathname, pageContext, false);
 
 		if (result && "redirect" in result) {
 			const location = String(result.redirect);
@@ -221,7 +221,7 @@ export async function loadRoute(
 				pathname += "/";
 			}
 
-			const result = findPage(
+			const result = await findPage(
 				notFoundRoutes,
 				url,
 				pathname + "$404",

--- a/packages/rakkasjs/src/runtime/page-types.ts
+++ b/packages/rakkasjs/src/runtime/page-types.ts
@@ -15,14 +15,14 @@ export type LayoutImporter = () => Promise<LayoutModule>;
 
 export interface PageModule {
 	default: Page;
-	action?: ActionHandler;
+	action?: ActionHandler<any>;
 	headers?: HeadersFunction;
 	prerender?: PrerenderFunction;
 }
 
 export interface LayoutModule {
 	default: Layout;
-	action?: ActionHandler;
+	action?: ActionHandler<any>;
 	headers?: HeadersFunction;
 	prerender?: PrerenderFunction;
 }
@@ -146,11 +146,11 @@ export interface PageRouteGuardContext<P = Record<string, string>>
 /** Page guard */
 export type PageRouteGuard<P = Record<string, string>> = (
 	ctx: PageRouteGuardContext<P>,
-) => LookupHookResult;
+) => LookupHookResult | Promise<LookupHookResult>;
 
-export type ActionHandler = (
+export type ActionHandler<T> = (
 	pageContext: ActionContext,
-) => ActionResult<any> | Promise<ActionResult<any>>;
+) => ActionResult<T> | Promise<ActionResult<T>>;
 
 /** Function to set response headers */
 export type HeadersFunction<M = Record<string, unknown>> = (
@@ -209,17 +209,16 @@ export interface Redirection {
 	headers?: Record<string, string | string[]> | ((headers: Headers) => void);
 }
 
-export type ActionResult<T> =
-	| Redirection
-	| {
-			data: T;
-			/** The status code */
-			status?: number;
-			/** Response headers */
-			headers?:
-				| Record<string, string | string[]>
-				| ((headers: Headers) => void);
-	  };
+export type ActionResult<T> = {
+	/** The data */
+	data: T;
+	/** Redirect to another URL */
+	redirect?: string | URL;
+	/** The status code */
+	status?: number;
+	/** Response headers */
+	headers?: Record<string, string | string[]> | ((headers: Headers) => void);
+};
 
 export type RouteConfigExport =
 	| RouteConfig

--- a/testbed/kitchen-sink/src/routes/form/(form).page.tsx
+++ b/testbed/kitchen-sink/src/routes/form/(form).page.tsx
@@ -1,7 +1,7 @@
 import { ActionHandler, PageProps, useSubmit } from "rakkasjs";
 
-export default function FormPage({ url, actionData }: PageProps) {
-	const submit = useSubmit();
+export default function FormPage({ url }: PageProps) {
+	const { data, status, submitHandler } = useSubmit<{ error?: string }>();
 
 	if (url.searchParams.has("done")) {
 		return <p>Thank you for your feedback!</p>;
@@ -10,26 +10,26 @@ export default function FormPage({ url, actionData }: PageProps) {
 	return (
 		<div>
 			<h1>Form</h1>
-			<form method="post" onSubmit={submit.submitHandler}>
+			<form method="post" onSubmit={submitHandler}>
 				<p>
 					<input name="name" type="text" />
 				</p>
-				{actionData && <p>{actionData}</p>}
+				{data?.error && <p>{data.error}</p>}
 				<p>
 					<button type="submit">Submit</button>
 				</p>
-				{submit.status === "loading" && <p>Submitting...</p>}
+				{status === "loading" && <p>Submitting...</p>}
 			</form>
 		</div>
 	);
 }
 
-export const action: ActionHandler = async (ctx) => {
+export const action: ActionHandler<{ error?: string }> = async (ctx) => {
 	const fd = await ctx.requestContext.request.formData();
 
 	if (fd.get("name") !== "correct") {
-		return { data: "Incorrect name" };
+		return { data: { error: "Incorrect name" } };
 	}
 
-	return { redirect: "/form?done" };
+	return { redirect: "/form?done", data: {} };
 };

--- a/testbed/kitchen-sink/src/routes/use-form-mutation/_useFormMutation.page.tsx
+++ b/testbed/kitchen-sink/src/routes/use-form-mutation/_useFormMutation.page.tsx
@@ -1,17 +1,17 @@
 import { PageProps, useFormMutation } from "rakkasjs";
 
 export default function UseFormMutationPage({ url }: PageProps) {
-	const { action, data, submitHandler, status } = useFormMutation(
-		async (ctx) => {
-			const fd = await ctx.request.formData();
+	const { action, data, submitHandler, status } = useFormMutation<{
+		error?: string;
+	}>(async (ctx) => {
+		const fd = await ctx.request.formData();
 
-			if (fd.get("name") !== "correct") {
-				return { data: "Incorrect name" };
-			}
+		if (fd.get("name") !== "correct") {
+			return { data: { error: "Incorrect name" } };
+		}
 
-			return { redirect: "?done" };
-		},
-	);
+		return { redirect: "?done", data: {} };
+	});
 
 	if (url.searchParams.has("done")) {
 		return <p>Thank you for your feedback!</p>;
@@ -24,7 +24,7 @@ export default function UseFormMutationPage({ url }: PageProps) {
 				<p>
 					<input name="name" type="text" />
 				</p>
-				{data && <p>{data}</p>}
+				{data?.error && <p>{data.error}</p>}
 				<p>
 					<button type="submit">Submit</button>
 				</p>


### PR DESCRIPTION
I still recommend returning synchronously when possible for performance reasons but async guards make a lot of things easier.

Example of synchronous return when possible:

```ts
import { userQuery } from "./user-query";
import type { User } from "./types";
import type { PageRouteGuard } from "rakkasjs";

export const pageGuard: PageRouteGuard = (ctx) => {
	// We try to return synchronously if possible for better performance

	function finish(user: User | null) {
		if (!user) {
			return {
				redirect: "/login",
				status: 302,
			};
		}

		return true;
	}

	const user = ctx.queryClient.getQueryData(userQuery.queryKey);
	if (user === undefined) {
		return ctx.queryClient.ensureQueryData(userQuery).then(finish);
	} else {
		return finish(user);
	}
};
```