### PR TITLE
fix: rewrite outermost suspense awaiting logic

### DIFF
--- a/examples/guide-samples/src/routes/client-suspense/index.page.tsx
+++ b/examples/guide-samples/src/routes/client-suspense/index.page.tsx
@@ -1,4 +1,4 @@
-import { ClientSuspense, Head } from "rakkasjs";
+import { ClientOnly, Head } from "rakkasjs";
 import { lazy } from "react";
 
 const ClientComponent = lazy(() => import("./ClientComponent"));
@@ -7,9 +7,9 @@ export default function ClientSuspensePage() {
 	return (
 		<div>
 			<Head title="Client suspense" />
-			<ClientSuspense fallback="Loading client-only component...">
+			<ClientOnly fallback="Loading client-only component...">
 				{<ClientComponent />}
-			</ClientSuspense>
+			</ClientOnly>
 		</div>
 	);
 }

--- a/packages/rakkasjs/src/features/client-only/implementation.tsx
+++ b/packages/rakkasjs/src/features/client-only/implementation.tsx
@@ -18,14 +18,14 @@ export function ClientOnly(props: ClientOnlyProps): ReactNode {
 		() => false,
 	);
 
-	return isHydrated ? props.children : props.fallback;
-}
-
-/** Suspense boundary that only runs on the client */
-export function ClientSuspense(props: ClientOnlyProps): ReactNode {
 	return (
-		<ClientOnly fallback={props.fallback}>
-			<Suspense fallback={props.fallback}>{props.children}</Suspense>
-		</ClientOnly>
+		<Suspense fallback={props.fallback}>
+			{isHydrated ? props.children : props.fallback}
+		</Suspense>
 	);
 }
+
+/**
+ * @deprecated {@link ClientOnly} now has the exact same functionality.
+ */
+export const ClientSuspense = ClientOnly;

--- a/packages/rakkasjs/src/features/client-only/lib.ts
+++ b/packages/rakkasjs/src/features/client-only/lib.ts
@@ -1,2 +1,6 @@
 export type { ClientOnlyProps } from "./implementation";
-export { ClientOnly, ClientSuspense } from "./implementation";
+export {
+	ClientOnly,
+	// eslint-disable-next-line deprecation/deprecation
+	ClientSuspense,
+} from "./implementation";

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -117,7 +117,6 @@ export function App(props: AppProps) {
 		)
 			.then((route) => {
 				lastRoute.last = route && { id, ...route };
-				lastRoute.onRendered?.();
 			})
 			.catch(async () => {
 				// Try a full reload in case of a mid-session deployment
@@ -154,7 +153,6 @@ interface RouteContextContent {
 		app: ReactElement;
 		actionData: any;
 	};
-	onRendered?(): void;
 	error?: unknown;
 	updateCounter?: number;
 }

--- a/packages/rakkasjs/src/runtime/client-entry.tsx
+++ b/packages/rakkasjs/src/runtime/client-entry.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode, Suspense } from "react";
+import React, { StrictMode } from "react";
 import { hydrateRoot, createRoot } from "react-dom/client";
 import { DEFAULT_QUERY_OPTIONS } from "../features/use-query/implementation";
 import {
@@ -115,9 +115,7 @@ export async function startClient(
 
 	app = (
 		<RouteContext.Provider value={"error" in route! ? route : { last: route }}>
-			<Suspense>
-				<ErrorBoundary FallbackComponent={ErrorComponent}>{app}</ErrorBoundary>
-			</Suspense>
+			<ErrorBoundary FallbackComponent={ErrorComponent}>{app}</ErrorBoundary>
 		</RouteContext.Provider>
 	);
 

--- a/testbed/kitchen-sink/src/routes/rakkas-css/(rakkas-css).page.tsx
+++ b/testbed/kitchen-sink/src/routes/rakkas-css/(rakkas-css).page.tsx
@@ -1,4 +1,4 @@
-import { useQuery, type Page, ClientSuspense, Link } from "rakkasjs";
+import { useQuery, type Page, ClientOnly, Link } from "rakkasjs";
 import { css } from "@rakkasjs/css";
 import { Suspense } from "react";
 
@@ -6,9 +6,9 @@ const RakkasCssPage: Page = () => {
 	return (
 		<>
 			<h1 className={css({ color: "red" })}>Hello</h1>
-			<ClientSuspense fallback={<p>Loading client-only component...</p>}>
+			<ClientOnly fallback={<p>Loading client-only component...</p>}>
 				<ClientOnlyComponent />
-			</ClientSuspense>
+			</ClientOnly>
 
 			<Suspense fallback={<p>Loading slow component...</p>}>
 				<SlowComponent />

--- a/testbed/kitchen-sink/src/routes/use-query/index.page.tsx
+++ b/testbed/kitchen-sink/src/routes/use-query/index.page.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from "rakkasjs";
-import { Suspense, useRef } from "react";
+import { useRef } from "react";
 
 export default function UseQueryPage() {
 	return (
 		<div>
 			<h1>useQuery</h1>
 			<div id="content">
-				<Suspense fallback={<p>Loading...</p>}>
-					<UseQueryDisplay />
-				</Suspense>
+				<UseQueryDisplay />
 			</div>
 		</div>
 	);
@@ -21,6 +19,7 @@ function UseQueryDisplay() {
 		"use-query",
 		async () => {
 			if (import.meta.env.SSR) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 1000));
 				return "SSR value";
 			} else {
 				await new Promise<void>((resolve) => {

--- a/website/src/lib/CodeViewer.tsx
+++ b/website/src/lib/CodeViewer.tsx
@@ -1,4 +1,4 @@
-import { ClientSuspense, useQuery } from "rakkasjs";
+import { ClientOnly, useQuery } from "rakkasjs";
 import css from "./CodeViewer.module.css";
 
 export interface CodeViewerProps {
@@ -12,7 +12,7 @@ export interface CodeViewerProps {
 
 export default function CodeViewer(props: CodeViewerProps) {
 	return (
-		<ClientSuspense
+		<ClientOnly
 			fallback={
 				<div className={css.main}>
 					<div className={css.second}>
@@ -22,7 +22,7 @@ export default function CodeViewer(props: CodeViewerProps) {
 			}
 		>
 			<CodeViewerInner {...props} />
-		</ClientSuspense>
+		</ClientOnly>
 	);
 }
 

--- a/website/src/routes/_site/guide/client-rendering.page.mdx
+++ b/website/src/routes/_site/guide/client-rendering.page.mdx
@@ -2,7 +2,7 @@
 title: Client rendering
 ---
 
-Rakkas provides a `ClientOnly` component for opting out of server-side rendering. It renders a fallback on the server and renders its children only on the client. `ClientSuspense` is similar but also acts as a suspense boundary and is usually the better choice. You can use [`React.lazy`](https://reactjs.org/docs/code-splitting.html#reactlazy) in combination with `ClientSuspense` to load components that don't support server-side rendering:
+Rakkas provides a `ClientOnly` component for opting out of server-side rendering. It renders a fallback on the server and renders its children only on the client. `ClientOnly` also acts as a suspense boundary. You can use [`React.lazy`](https://reactjs.org/docs/code-splitting.html#reactlazy) in combination with `ClientOnly` to load components that don't support server-side rendering:
 
 <CodeViewer
   name="guide-samples"
@@ -13,4 +13,4 @@ Rakkas provides a `ClientOnly` component for opting out of server-side rendering
   url="/client-suspense"
 />
 
-Another use of `ClientOnly` and `ClientSuspense` is to wrap a layout's children to disable SSR for parts of an application.
+Another use of `ClientOnly` is to wrap a layout's children to disable SSR for parts of an application.


### PR DESCRIPTION
Rakkas used to try to await for the outermost suspense to resolve but it wasn't really working. It appears that React has no documented way of doing it. But it turns out that simply not using an outermost suspense just works.

But this required a few changes elsewhere. Most notably, the `ClientSuspense` component is now deprecated, `ClientOnly` does the exact same thing.