### PR TITLE
feat: allow VITE_ env prefix

### DIFF
--- a/packages/rakkasjs/src/vite-plugin/inject-config.ts
+++ b/packages/rakkasjs/src/vite-plugin/inject-config.ts
@@ -100,7 +100,7 @@ export function injectConfig(options: InjectConfigOptions): Plugin {
 					],
 				},
 
-				envPrefix: "RAKKAS_",
+				envPrefix: ["VITE_", "RAKKAS_"],
 
 				api: {
 					rakkas: {


### PR DESCRIPTION
With this PR, Rakkas now allows the more standard `VITE_` prefix in addition to the `RAKKAS_` prefix in environment variables exposed to the client via `import.meta.env`.