### PR TITLE
feat: make some improvements for Rakkas hooks

### DIFF
--- a/packages/rakkasjs/src/features/client-side-navigation/implementation/history.ts
+++ b/packages/rakkasjs/src/features/client-side-navigation/implementation/history.ts
@@ -109,7 +109,9 @@ function handlePopState() {
 function finishNavigation(targetId: string) {
 	const { promise, resolve } = Promise.withResolvers<void>();
 
-	navigationPromise = promise;
+	navigationPromise = promise.then(() => {
+		rakkas.emitNavigationEvent?.(new URL(location.href));
+	});
 	navigationResolve = resolve;
 
 	startTransition(() => {

--- a/packages/rakkasjs/src/internal/find-page.tsx
+++ b/packages/rakkasjs/src/internal/find-page.tsx
@@ -25,7 +25,10 @@ export async function findPage<
 
 	if (!notFound) {
 		for (const handler of beforePageLookupHandlers) {
-			const result = handler(lookupContext);
+			let result = handler(lookupContext);
+			if (result instanceof Promise) {
+				result = await result;
+			}
 
 			if (!result) return undefined;
 

--- a/packages/rakkasjs/src/lib/types.ts
+++ b/packages/rakkasjs/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface RakkasBrowserGlobal {
 	headTagStack: (HeadProps & { order: number })[];
 	headOrder: number;
 	setNextId?: (id: string) => void;
+	emitNavigationEvent?: (url: URL) => void;
 }
 
 declare global {

--- a/packages/rakkasjs/src/runtime/App.tsx
+++ b/packages/rakkasjs/src/runtime/App.tsx
@@ -384,11 +384,16 @@ export async function loadRoute(
 	};
 }
 
+let initialNavigationEventEmitted = false;
 function Finish() {
 	const resolve = navigationResolve;
 
 	useEffect(() => {
 		resolve?.();
+		if (!initialNavigationEventEmitted) {
+			initialNavigationEventEmitted = true;
+			rakkas.emitNavigationEvent?.(new URL(location.href));
+		}
 	}, [resolve]);
 
 	return <Scroll />;

--- a/packages/rakkasjs/src/runtime/client-entry.tsx
+++ b/packages/rakkasjs/src/runtime/client-entry.tsx
@@ -125,6 +125,17 @@ export async function startClient(
 
 	const container = document.getElementById("root")!;
 
+	const onNavigateHooks = sortHooks([
+		...hooks.map((hook) => hook.onNavigation),
+		options.hooks?.onNavigation,
+	]);
+
+	rakkas.emitNavigationEvent = (url: URL) => {
+		for (const hook of onNavigateHooks) {
+			hook(url);
+		}
+	};
+
 	if (rakkas.clientRender) {
 		createRoot(container).render(app);
 	} else {

--- a/packages/rakkasjs/src/runtime/client-hooks.ts
+++ b/packages/rakkasjs/src/runtime/client-hooks.ts
@@ -16,6 +16,12 @@ export interface ClientHooks {
 	 * components on the client only.
 	 */
 	wrapApp?(app: ReactElement): ReactElement;
+	/**
+	 * This hook is called when the user navigates to a new page, including when
+	 * it is first hydrated/rendered on the client. It can be used for tracking
+	 * page views or sending analytics events.
+	 */
+	onNavigation?: HookDefinition<(url: URL) => void>;
 }
 
 export function defineClientHooks(hooks: ClientHooks): ClientHooks {

--- a/packages/rakkasjs/src/runtime/common-hooks.ts
+++ b/packages/rakkasjs/src/runtime/common-hooks.ts
@@ -19,7 +19,7 @@ export interface CommonHooks {
 	 * rewriting or redirecting the URL.
 	 */
 	beforePageLookup?: HookDefinition<
-		(ctx: LookupHookContext) => LookupHookResult
+		(ctx: LookupHookContext) => LookupHookResult | Promise<LookupHookResult>
 	>;
 
 	/**

--- a/testbed/kitchen-sink/src/entry-client.ts
+++ b/testbed/kitchen-sink/src/entry-client.ts
@@ -1,0 +1,10 @@
+import { startClient } from "rakkasjs/client";
+
+startClient({
+	hooks: {
+		onNavigation(url) {
+			// eslint-disable-next-line no-console
+			console.log("Soft-navigated to", url.href);
+		},
+	},
+}).catch(console.error);


### PR DESCRIPTION
This PR implements two new features related to Rakkas hooks:

- `onBeforePageLookup` common hook can now be async. Same performance caveats apply as #268.
- There's now a new `onNavigation` client hook fired when a client-side navigation completes and also on initial hydration/rendering. It is useful for tracking page views and sending analytics events among other things.