### PR TITLE
feat: call hydrateRoot in startTransition

### DIFF
--- a/packages/rakkasjs/src/runtime/client-entry.tsx
+++ b/packages/rakkasjs/src/runtime/client-entry.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode } from "react";
+import React, { startTransition, StrictMode } from "react";
 import { hydrateRoot, createRoot } from "react-dom/client";
 import { DEFAULT_QUERY_OPTIONS } from "../features/use-query/implementation";
 import {
@@ -139,6 +139,8 @@ export async function startClient(
 	if (rakkas.clientRender) {
 		createRoot(container).render(app);
 	} else {
-		hydrateRoot(container, app);
+		startTransition(() => {
+			hydrateRoot(container, app);
+		});
 	}
 }


### PR DESCRIPTION
This PR implements non-blocking hydration by calling `hydrateRoot` in `startTransition`. This is a bit of an arcane feature of React that isn't well documented. My knowledge comes from [this tweet](https://x.com/jamannnnnn/status/1567850622568865793) but unfortunately Dan Abramov closed his account so the full conversation is no longer available. But both Next.js and Remix use this trick.