### PR TITLE
fix: don't return stale value from useQuery

### DIFF
--- a/packages/rakkasjs/src/features/use-query/client-hooks.tsx
+++ b/packages/rakkasjs/src/features/use-query/client-hooks.tsx
@@ -96,17 +96,31 @@ const cache: QueryCache = {
 
 			valueOrPromise
 				.then((value) => {
+					queryCache[key] ||= {
+						date: Date.now(),
+						hydrated: false,
+						subscribers: new Set(),
+						cacheTime,
+					};
 					queryCache[key] = {
 						...queryCache[key]!,
 						value,
 						hydrated: false,
 						date: Date.now(),
 					};
+
 					delete queryCache[key]!.invalid;
 					delete queryCache[key]!.promise;
 				})
 				.catch((error) => {
+					queryCache[key] ||= {
+						date: Date.now(),
+						hydrated: false,
+						subscribers: new Set(),
+						cacheTime,
+					};
 					queryCache[key] = { ...queryCache[key]!, error };
+
 					delete queryCache[key]!.promise;
 					throw error;
 				})

--- a/packages/rakkasjs/src/features/use-query/implementation.ts
+++ b/packages/rakkasjs/src/features/use-query/implementation.ts
@@ -320,9 +320,8 @@ function useQueryBase<
 
 	const [initialEnabled] = useState(enabled);
 
-	const [item, setItem] = useState<CacheItem | undefined>(() =>
-		queryKey === undefined ? undefined : cache.get(queryKey),
-	);
+	const [, forceUpdate] = useState(0);
+	const item = queryKey === undefined ? undefined : cache.get(queryKey);
 
 	useEffect(() => {
 		if (queryKey === undefined) {
@@ -330,9 +329,11 @@ function useQueryBase<
 		}
 
 		return cache.subscribe(queryKey, () => {
-			setItem(cache.get(queryKey));
+			if (cache.get(queryKey) !== item) {
+				forceUpdate((c) => (c + 1) & 0xffff);
+			}
 		});
-	}, [cache, queryKey]);
+	}, [cache, queryKey, item]);
 
 	const ctx = usePageContext();
 


### PR DESCRIPTION
`useQuery` was returning stale data under some circumstances (probably since #273). This PR fixes it.