### PR TITLE
fix: sort server hooks to prepare `ctx.fetch` before calling ssq

### DIFF
--- a/packages/rakkasjs/src/runtime/feature-server-hooks.tsx
+++ b/packages/rakkasjs/src/runtime/feature-server-hooks.tsx
@@ -10,8 +10,8 @@ const serverFeatureHooks: ServerHooks[] = [
 	asyncLocalRequestContextServerHooks,
 	headHooks,
 	useQueryHooks,
-	useServerSideHooks,
 	isomorphicFetchHooks,
+	useServerSideHooks,
 	clientSideNavigationHooks,
 ];
 


### PR DESCRIPTION
fix #286 