### PR TITLE
feat: make StyledLink accept functions for className and style props

### DIFF
--- a/packages/rakkasjs/src/features/client-side-navigation/implementation/link.tsx
+++ b/packages/rakkasjs/src/features/client-side-navigation/implementation/link.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import React, {
 	type AnchorHTMLAttributes,
 	type CSSProperties,
@@ -219,14 +220,26 @@ export interface StyledLinkProps
 		| CSSProperties
 		| ((state: { isPending: boolean; isCurrent: boolean }) => CSSProperties);
 
-	/** Class to be added if `href` matches the current URL */
+	/**
+	 * Class to be added if `href` matches the current URL.
+	 * @deprecated pass a function as the `className` prop
+	 */
 	activeClass?: string;
-	/** Style to be added if `href` matches the current URL */
+	/**
+	 * Style to be added if `href` matches the current URL.
+	 * @deprecated pass a function as the `style` prop
+	 */
 	activeStyle?: CSSProperties;
 
-	/** Class to be added if navigation is underway because the user clicked on this link */
+	/**
+	 * Class to be added if navigation is underway because the user clicked on this link.
+	 * @deprecated pass a function as the `className` prop
+	 */
 	pendingClass?: string;
-	/** Style to be added if navigation is underway because the user clicked on this link */
+	/**
+	 * Style to be added if navigation is underway because the user clicked on this link.
+	 * @deprecated pass a function as the `style` prop
+	 */
 	pendingStyle?: CSSProperties;
 
 	/**


### PR DESCRIPTION
This PR makes the `StyledLink` function accept functions for the `className` and `style` props, making state-dependent styling easier.

The functions are passed an object with two boolean properties `isCurrent` and `isPending`.

The old styling props `activeClass`, `pendingClass`, `pendingStyle`, and `activeStyle` are now deprecated.